### PR TITLE
Enable hash table asserts in debug builds

### DIFF
--- a/mir-htab.h
+++ b/mir-htab.h
@@ -15,8 +15,8 @@ extern "C" {
 #define FALSE 0
 #define TRUE 1
 
-#if !defined(VARR_ENABLE_CHECKING) && !defined(NDEBUG)
-#define VARR_ENABLE_CHECKING
+#if !defined(HTAB_ENABLE_CHECKING) && !defined(NDEBUG)
+#define HTAB_ENABLE_CHECKING
 #endif
 
 #ifndef HTAB_ENABLE_CHECKING


### PR DESCRIPTION
## Summary
- ensure `HTAB_ENABLE_CHECKING` is defined for debug builds so hash table assertions work

## Testing
- `gcc -std=gnu11 adt-tests/mir-htab-test.c -I. -o /tmp/mir-htab-test && /tmp/mir-htab-test`


------
https://chatgpt.com/codex/tasks/task_e_689245a0aa608326b9c45fc4478f84f8