### PR TITLE
basic: handle rem and dim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@
   - `-j` to execute with the JIT generator.
   - `-S` or `-c` to emit MIR text (`.mir`) and binary (`.bmir`) files.
   - `-o <path>` to set the base name for generated MIR files.
+  - The compiler now understands `REM` comments and ignores `DIM` statements.


### PR DESCRIPTION
## Summary
- extend BASIC compiler to parse REM and DIM statements
- document comment and DIM support in agent instructions

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_6892810321708326a6daa1a241d43aed