### PR TITLE
Support multiple BASIC print items

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -8,9 +8,9 @@ double basic_input (void) {
   return x;
 }
 
-void basic_print (double x) { printf ("%g\n", x); }
+void basic_print (double x) { printf ("%g", x); }
 
-void basic_print_str (const char *s) { puts (s); }
+void basic_print_str (const char *s) { fputs (s, stdout); }
 
 char *basic_input_str (void) {
   char buf[256];


### PR DESCRIPTION
## Summary
- Parse PRINT statements into lists of items, tracking trailing separators to control newline emission
- Generate print helper calls for each item and emit a final newline only when needed
- Adjust BASIC runtime helpers to print without automatic newline

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_6892944976988326a83dfdf3d670257d