### PR TITLE
Add HTAB statement

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -69,7 +69,8 @@ void basic_key_off (void) {}
 
 void basic_locate (double r, double c) { printf ("\x1b[%d;%dH", (int) r, (int) c); }
 
-void basic_tab (double n) { printf ("\x1b[%dG", (int) n); }
+void basic_htab (double n) { printf ("\x1b[%dG", (int) n); }
+void basic_tab (double n) { basic_htab (n); }
 
 double basic_rnd (double n) {
   static int seeded = 0;


### PR DESCRIPTION
## Summary
- add `HTAB` statement and map to `basic_htab` runtime helper
- support aliasing `basic_tab` to `basic_htab`

## Testing
- `make basic-test`
- `./build/basic/basicc examples/basic/periodic.bas > build/basic/periodic.out && diff examples/basic/periodic.out build/basic/periodic.out` *(fails: func main: in instruction 'mov': unexpected operand mode for operand #2. Got 'label', expected 'int')*

------
https://chatgpt.com/codex/tasks/task_e_6892a5a448088326b79608ce874f7ad7