### PR TITLE
Add BASIC graphics and text commands

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -130,3 +130,20 @@ void basic_poke (double addr, double value) {
   if (a < 0 || a >= BASIC_MEM_SIZE) return;
   basic_memory[a] = (uint8_t) v;
 }
+
+void basic_text (void) { printf ("\x1b[0m\x1b[2J\x1b[H"); }
+
+void basic_inverse (void) { printf ("\x1b[7m"); }
+
+void basic_normal (void) { printf ("\x1b[0m"); }
+
+void basic_hgr2 (void) { printf ("\x1b[2J\x1b[H"); }
+
+static int current_hcolor = 37;
+
+void basic_hcolor (double c) { current_hcolor = 30 + ((int) c & 7); }
+
+void basic_hplot (double x, double y) {
+  printf ("\x1b[%dm\x1b[%d;%dH*\x1b[0m", current_hcolor, (int) y, (int) x);
+  fflush (stdout);
+}


### PR DESCRIPTION
## Summary
- support additional BASIC statements: TEXT, INVERSE, NORMAL, HGR2, HCOLOR=, HPLOT
- wire MIR generation to new runtime helpers
- provide runtime helpers for text mode, inverse/normal video, graphics color, and plotting

## Testing
- `make basic-test`
- `./build/basic/basicc examples/basic/periodic.bas > build/basic/periodic.out && diff examples/basic/periodic.out build/basic/periodic.out` *(fails: func main: in instruction 'mov': unexpected operand mode for operand #2. Got 'label', expected 'int')*

------
https://chatgpt.com/codex/tasks/task_e_6892a983966c8326afc281ad630c5c5f