### PR TITLE
docs: expand BASIC instruction list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,6 @@
   - loops (`FOR`/`NEXT`, `WHILE`/`WEND`).
   - arrays via `DIM` and indexed variables.
   - `DATA`, `READ`, and `RESTORE` statements.
-  - graphics commands such as `HOME` and `VTAB`.
+  - graphics commands such as `HOME`, `VTAB`, `HTAB`, `TEXT`, `INVERSE`, `NORMAL`, `HGR2`, `HCOLOR=`, and `HPLOT`.
+  - memory and spacing operations like `PEEK`, `POKE`, and `SPC`.
 


### PR DESCRIPTION
## Summary
- document more supported BASIC commands in repository guidelines

## Testing
- `make basic-test`
- `./build/basic/basicc examples/basic/periodic.bas > build/basic/periodic.out && diff examples/basic/periodic.out build/basic/periodic.out` *(fails: unexpected operand mode for operand #2)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab4c175483269be399f8fad81149