### PR TITLE
Skip blank BASIC lines

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3097,6 +3097,9 @@ int main (int argc, char **argv) {
   LineVec prog = {0};
   char line[256];
   while (fgets (line, sizeof (line), f)) {
+    char *p = line;
+    while (isspace ((unsigned char) *p)) p++;
+    if (*p == '\0') continue;
     Line l;
     if (parse_line (line, &l))
       line_vec_push (&prog, l);


### PR DESCRIPTION
## Summary
- avoid spurious parse errors by ignoring blank BASIC lines

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`
- `grep -n 'parse error' /tmp/basic-test.log`

------
https://chatgpt.com/codex/tasks/task_e_6892c59a908c8326ac50a158b9297388