### PR TITLE
Fix BASIC benchmark script for fish shell

### DIFF
--- a/examples/basic/run-benchmarks.sh
+++ b/examples/basic/run-benchmarks.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Run BASIC benchmarks in JIT and compiled modes.
-set -e
-ROOT="$(realpath "$(dirname "$0")/../../")"
-BUILD_DIR="$ROOT"
-BASICC="$BUILD_DIR/basic/basicc"
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../../" && pwd)"
+BASICC="$ROOT/basic/basicc"
 
 # Build basicc if necessary
 if [ ! -x "$BASICC" ]; then
-  make -C "$ROOT" "$BASICC"
+  (cd "$ROOT" && make basic/basicc)
 fi
 
 run_bench() {
@@ -15,10 +15,10 @@ run_bench() {
   local file="$ROOT/examples/basic/${name}.bas"
   echo "== ${name} =="
   echo "-- JIT --"
-  time -p "$BASICC" -j "$file" >/dev/null
+  (cd "$ROOT" && time -p "$BASICC" -j "$file" >/dev/null)
   echo "-- Compiled --"
-  time -p "$BASICC" -b -o "$BUILD_DIR/basic/${name}-bench" "$file" >/dev/null
-  time -p "$BUILD_DIR/basic/${name}-bench" >/dev/null
+  (cd "$ROOT" && time -p "$BASICC" -b -o "$ROOT/basic/${name}-bench" "$file" >/dev/null)
+  time -p "$ROOT/basic/${name}-bench" >/dev/null
 }
 
 run_bench sieve


### PR DESCRIPTION
## Summary
- make run-benchmarks.sh independent of current shell
- call `make basic/basicc` with relative path
- run benchmarks from repo root so compile mode finds sources

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`
- `examples/basic/run-benchmarks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892c8b6f8688326ba189b2bff1b1ee4