### PR TITLE
Expand BASIC benchmark loops

### DIFF
--- a/examples/basic/fib.bas
+++ b/examples/basic/fib.bas
@@ -1,6 +1,6 @@
 5 REM Fibonacci benchmark
 10 N = 35
-20 ITER = 1000
+20 ITER = 20000
 30 FOR J = 1 TO ITER
 40  A = 0
 50  B = 1

--- a/examples/basic/sieve.bas
+++ b/examples/basic/sieve.bas
@@ -1,6 +1,6 @@
 5 REM Sieve of Eratosthenes benchmark
 10 S = 8190
-20 N = 100
+20 N = 2000
 30 DIM A(8190)
 40 FOR J = 1 TO N
 50  FOR I = 0 TO S - 1


### PR DESCRIPTION
## Summary
- Increase iterations in BASIC `sieve` and `fib` benchmarks to lengthen runtime

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6892cb110d7c8326ad59b652a330474a