### PR TITLE
Document tab-only indentation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # MIR repository agent instructions
 
 ## Formatting
+- Use tabs for indentation in source files and verify this before submitting patches to avoid unnecessary token waste.
 - Run `clang-format -i` on any modified C source files before committing.
 
 ## Testing


### PR DESCRIPTION
## Summary
- document using tabs for indentation and verifying before submitting patches to avoid token waste

## Testing
- `make basic-test` *(fails: Killed (exit 137))*

------
https://chatgpt.com/codex/tasks/task_e_6893305e2ea0832693bdaea721ff3a1c