### PR TITLE
Fix integer operand handling in BASIC codegen

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -422,6 +422,8 @@ basic-test: $(BUILD_DIR)/basic/basicc$(EXE)
 	diff $(SRC_DIR)/examples/basic/instr.out $(BUILD_DIR)/basic/instr.out
 	$(BUILD_DIR)/basic/basicc$(EXE) $(SRC_DIR)/examples/basic/array.bas > $(BUILD_DIR)/basic/array.out
 	diff $(SRC_DIR)/examples/basic/array.out $(BUILD_DIR)/basic/array.out
+	$(BUILD_DIR)/basic/basicc$(EXE) $(SRC_DIR)/examples/basic/on.bas > $(BUILD_DIR)/basic/on.out
+	diff $(SRC_DIR)/examples/basic/on.out $(BUILD_DIR)/basic/on.out
 	        $(BUILD_DIR)/basic/basicc$(EXE) $(SRC_DIR)/examples/basic/while.bas > $(BUILD_DIR)/basic/while.out
 	        diff $(SRC_DIR)/examples/basic/while.out $(BUILD_DIR)/basic/while.out
 	        $(BUILD_DIR)/basic/basicc$(EXE) $(SRC_DIR)/examples/basic/ifcolons.bas > $(BUILD_DIR)/basic/ifcolons.out


### PR DESCRIPTION
## Summary
- ensure ON...GOTO and ON...GOSUB use integer comparisons
- emit HPLOT statements using integer coordinates
- exercise ON statement handling in basic-test

## Testing
- `make basic-test` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68934790b7a08326bf48794dad4c6a50