### PR TITLE
Expand BASIC compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,4 +38,6 @@
 - `basic/basicc` entered an infinite loop when parsing programs ending with `END` or `STOP`.
 - The cursor in `parse_stmt` was not advanced for these keywords, causing the loop in `parse_line` to never progress.
 - Advancing the cursor for `END`/`STOP` and restoring a colon check after each statement resolves the issue.
+- `fleuves.bas` could not be parsed due to unhandled empty statements and missing loop generation.
+- Allowing consecutive or trailing colons and emitting MIR for `FOR`/`NEXT` and `WHILE`/`WEND` enables complex BASIC programs to run.
 


### PR DESCRIPTION
## Summary
- enhance BASIC parsing to handle repeated colons, prompts on INPUT, and graphics/memory ops
- generate MIR for FOR/NEXT, WHILE/WEND loops, READ/RESTORE/POKE, and HPLOT variations
- document BASIC compiler extensions and caveats

## Testing
- `make basic-test` *(fails: Files examples/basic/graphics.out and basic/graphics.out differ)*
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_68937154b8f88326b8fa7c7297313977