### PR TITLE
Handle NULL pointers in basic_strcmp

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -84,7 +84,13 @@ void basic_put (const char *s) {
   fputc (c, stdout);
 }
 
-int basic_strcmp (const char *a, const char *b) { return strcmp (a, b); }
+int basic_strcmp (const char *a, const char *b) {
+  if (a == NULL || b == NULL) {
+    if (a == b) return 0;
+    return a == NULL ? -1 : 1;
+  }
+  return strcmp (a, b);
+}
 
 #define BASIC_MAX_FILES 16
 static FILE *basic_files[BASIC_MAX_FILES];


### PR DESCRIPTION
## Summary
- Make `basic_strcmp` resilient to NULL string inputs

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6893adeec6dc8326ac7ced210f677a86