### PR TITLE
Fix REPL gen_program call for new reduce_libs parameter

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3427,7 +3427,7 @@ static void repl (void) {
       continue;
     }
     if (strcasecmp (p, "RUN") == 0) {
-      gen_program (&prog, 0, 0, 0, 0, NULL, "(repl)");
+      gen_program (&prog, 0, 0, 0, 0, 0, NULL, "(repl)");
       continue;
     }
     if (strcasecmp (p, "LIST") == 0) {


### PR DESCRIPTION
## Summary
- pass reduce_libs argument when REPL invokes `gen_program`

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6893c665f5ac832691e1b3797f4bb70d