### PR TITLE
Add option to emit bmir from BASIC compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - `examples/basic/basicc.c` accepts:
   - `-j` to execute with the JIT generator.
   - `-S` or `-c` to emit MIR text (`.mir`) and binary (`.bmir`) files.
+  - `-r` to emit only a binary (`.bmir`) file for use with `mir-bin-run`.
   - `-b` to build a standalone executable.
   - `-l` to reduce linked libraries when building executables.
   - `-o <path>` to set the base name for generated files.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -435,3 +435,5 @@ basic-test: $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE)
 	diff $(SRC_DIR)/examples/basic/hello.out $(BUILD_DIR)/basic/hello-lean.out
 	$(BUILD_DIR)/basic/kitty_test$(EXE) > $(BUILD_DIR)/basic/kitty_test.out
 	diff $(SRC_DIR)/examples/basic/kitty/kitty_test.out $(BUILD_DIR)/basic/kitty_test.out
+	$(BUILD_DIR)/basic/basicc$(EXE) -r -o $(BUILD_DIR)/basic/hello $(SRC_DIR)/examples/basic/hello.bas
+	test -f $(BUILD_DIR)/basic/hello.bmir

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3455,6 +3455,8 @@ int main (int argc, char **argv) {
       asm_p = obj_p = 1;
     } else if (strcmp (argv[i], "-c") == 0) {
       asm_p = obj_p = 1;
+    } else if (strcmp (argv[i], "-r") == 0) {
+      obj_p = 1;
     } else if (strcmp (argv[i], "-b") == 0) {
       bin_p = 1;
     } else if (strcmp (argv[i], "-l") == 0) {


### PR DESCRIPTION
## Summary
- add `-r` option to `basicc` to output `.bmir` for `mir-bin-run`
- exercise `-r` option in `basic-test`
- document new option

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6893c835a6508326939a76c531290674