### PR TITLE
Add REPL compile/save commands and test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -447,6 +447,10 @@ basic-test: $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) 
 	diff $(SRC_DIR)/examples/basic/array_default.out $(BUILD_DIR)/basic/array_default.out
 	printf '10 PRINT "HI"\nRUN\nQUIT\n' | $(BUILD_DIR)/basic/basicc$(EXE) > $(BUILD_DIR)/basic/repl.out
 	diff $(SRC_DIR)/examples/basic/repl.out $(BUILD_DIR)/basic/repl.out
+	printf '10 PRINT "HELLO"\nSAVE $(BUILD_DIR)/basic/repl-save$(EXE)\nQUIT\n' | $(BUILD_DIR)/basic/basicc$(EXE) > $(BUILD_DIR)/basic/repl-save.log
+	test -f $(BUILD_DIR)/basic/repl-save$(EXE)
+	$(BUILD_DIR)/basic/repl-save$(EXE) > $(BUILD_DIR)/basic/repl-save.out
+	diff $(SRC_DIR)/examples/basic/hello.out $(BUILD_DIR)/basic/repl-save.out
 	$(BUILD_DIR)/basic/basicc$(EXE) -b -l -o $(BUILD_DIR)/basic/hello-lean $(SRC_DIR)/examples/basic/hello.bas
 	$(BUILD_DIR)/basic/hello-lean$(EXE) > $(BUILD_DIR)/basic/hello-lean.out
 	diff $(SRC_DIR)/examples/basic/hello.out $(BUILD_DIR)/basic/hello-lean.out

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3430,6 +3430,55 @@ static void repl (void) {
       gen_program (&prog, 0, 0, 0, 0, 0, NULL, "(repl)");
       continue;
     }
+    if (strncasecmp (p, "COMPILE", 7) == 0) {
+      p += 7;
+      while (isspace ((unsigned char) *p)) p++;
+      if (strncasecmp (p, "NATIVE", 6) == 0) {
+        p += 6;
+        while (isspace ((unsigned char) *p)) p++;
+        if (*p == '\0') {
+          fprintf (stderr, "missing output file\n");
+        } else {
+          gen_program (&prog, 0, 0, 0, 1, 0, p, "(repl)");
+          if (access (p, F_OK) == 0)
+            printf ("%s\n", p);
+          else
+            perror (p);
+        }
+        continue;
+      } else if (strncasecmp (p, "BMIR", 4) == 0) {
+        p += 4;
+        while (isspace ((unsigned char) *p)) p++;
+        if (*p == '\0') {
+          fprintf (stderr, "missing output file\n");
+        } else {
+          gen_program (&prog, 0, 0, 1, 0, 0, p, "(repl)");
+          char *name = change_suffix (p, ".bmir");
+          if (access (name, F_OK) == 0)
+            printf ("%s\n", name);
+          else
+            perror (name);
+          free (name);
+        }
+        continue;
+      }
+      fprintf (stderr, "unknown COMPILE target\n");
+      continue;
+    }
+    if (strncasecmp (p, "SAVE", 4) == 0) {
+      p += 4;
+      while (isspace ((unsigned char) *p)) p++;
+      if (*p == '\0') {
+        fprintf (stderr, "missing output file\n");
+      } else {
+        gen_program (&prog, 0, 0, 0, 1, 0, p, "(repl)");
+        if (access (p, F_OK) == 0)
+          printf ("Saved %s\n", p);
+        else
+          perror (p);
+      }
+      continue;
+    }
     if (strcasecmp (p, "LIST") == 0) {
       for (size_t i = 0; i < prog.len; i++) printf ("%s\n", prog.data[i].src);
       continue;


### PR DESCRIPTION
## Summary
- Add COMPILE and SAVE commands to the BASIC REPL so interactive programs can emit executables or BMIR files and report output paths
- Exercise SAVE in basic-test by compiling a REPL program and running the resulting binary

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6893d4edde80832696404b32f30d4f12