### PR TITLE
Track helper function usage for leaner binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -524,9 +524,9 @@ clean-mir-interp-tests:
 .PHONY: clean-mir-gen-tests
 .PHONY: gen-test gen-test-loop gen-test-sieve gen-issue219-test gen-test-get-thunk-addr
 .PHONY: gen-test1 gen-test2 gen-test3 gen-test4 gen-test5 gen-test6 gen-test7
-.PHONY: gen-test8 gen-test9 gen-test10 gen-test11 gen-test12 gen-test13 gen-test14 gen-test15 gen-test16
+.PHONY: gen-test8 gen-test9 gen-test10 gen-test11 gen-test12 gen-test13 gen-test14 gen-test15 gen-test16 helper-bitmap-test
 gen-test: gen-test-loop gen-test-sieve gen-test-get-thunk-addr gen-issue219-test gen-test1 gen-test2 gen-test3 gen-test4 gen-test5 gen-test6 gen-test7\
-	  gen-test8 gen-test9 gen-test10 gen-test11 gen-test12 gen-test13 gen-test14 gen-test15 gen-test16
+          gen-test8 gen-test9 gen-test10 gen-test11 gen-test12 gen-test13 gen-test14 gen-test15 gen-test16 helper-bitmap-test
 gen-test-loop: $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) $(SRC_DIR)/mir-tests/loop-sieve-gen.c | $(BUILD_DIR)/mir-tests
 	$(COMPILE_AND_LINK) -DTEST_GEN_LOOP -DTEST_GEN_DEBUG=1 $^ $(LDLIBS) $(EXEO)$(BUILD_DIR)/mir-tests/gen-loop-test$(EXE)
 	$(BUILD_DIR)/mir-tests/gen-loop-test
@@ -574,10 +574,13 @@ gen-test14: $(BUILD_DIR)/run-test$(EXE)
 gen-test15: $(BUILD_DIR)/run-test$(EXE)
 	$(BUILD_DIR)/run-test$(EXE) -g $(SRC_DIR)/mir-tests/test15.mir
 gen-test16: $(BUILD_DIR)/run-test$(EXE)
-	$(BUILD_DIR)/run-test$(EXE) -g $(SRC_DIR)/mir-tests/test16.mir
+	        $(BUILD_DIR)/run-test$(EXE) -g $(SRC_DIR)/mir-tests/test16.mir
+helper-bitmap-test: $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) $(SRC_DIR)/mir-tests/helper-bitmap.c | $(BUILD_DIR)/mir-tests
+	$(COMPILE_AND_LINK) $^ $(LDLIBS) $(EXEO)$(BUILD_DIR)/mir-tests/helper-bitmap-test$(EXE)
+	$(BUILD_DIR)/mir-tests/helper-bitmap-test$(EXE)
 clean-mir-gen-tests:
-	$(RM) $(BUILD_DIR)/mir-tests/gen-loop-test$(EXE) $(BUILD_DIR)/mir-tests/gen-sieve-test$(EXE)
-	$(RM) $(BUILD_DIR)/mir-tests/issue219$(EXE) $(BUILD_DIR)/mir-tests/gen-get-thunk-addr-test
+	        $(RM) $(BUILD_DIR)/mir-tests/gen-loop-test$(EXE) $(BUILD_DIR)/mir-tests/gen-sieve-test$(EXE)
+	        $(RM) $(BUILD_DIR)/mir-tests/issue219$(EXE) $(BUILD_DIR)/mir-tests/gen-get-thunk-addr-test $(BUILD_DIR)/mir-tests/helper-bitmap-test$(EXE)
 # ------------------ MIR run tests --------------------------
 mir-bin-run-test: $(BUILD_DIR)/mir-bin-run$(EXE) $(BUILD_DIR)/c2m$(EXE)
 	      $(BUILD_DIR)/c2m$(EXE) -c $(SRC_DIR)/sieve.c

--- a/mir-tests/helper-bitmap.c
+++ b/mir-tests/helper-bitmap.c
@@ -1,0 +1,33 @@
+#include "mir.h"
+#include "mir-gen.h"
+#include "mir-bitmap.h"
+#include <assert.h>
+
+int main (void) {
+  MIR_context_t ctx = MIR_init ();
+  MIR_module_t m = MIR_new_module (ctx, "m");
+  MIR_type_t res_type = MIR_T_F;
+  MIR_var_t arg = {MIR_T_U64, "u"};
+  MIR_func_t func = MIR_new_func_arr (ctx, "f", 1, &res_type, 1, &arg);
+  MIR_reg_t res = MIR_new_func_reg (ctx, func, MIR_T_F, "res");
+  MIR_reg_t u = MIR_reg ("u", func);
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_UI2F, MIR_new_reg_op (ctx, res),
+                                 MIR_new_reg_op (ctx, u)));
+  MIR_append_insn (ctx, func, MIR_new_ret_insn (ctx, 1, MIR_new_reg_op (ctx, res)));
+  MIR_finish_func (ctx);
+  MIR_finish_module (ctx);
+  MIR_load_module (ctx, m);
+  MIR_gen_init (ctx);
+  MIR_link (ctx, MIR_set_gen_interface, NULL);
+  MIR_gen (ctx, DLIST_HEAD (MIR_item_t, m->items));
+  bitmap_t bm = _MIR_get_helpers_bitset (ctx);
+  int ui2f_idx = _MIR_helper_num (ctx, "mir.ui2f");
+  int va_arg_idx = _MIR_helper_num (ctx, "mir.va_arg");
+  assert (ui2f_idx >= 0 && va_arg_idx >= 0);
+  assert (bitmap_bit_p (bm, ui2f_idx));
+  assert (!bitmap_bit_p (bm, va_arg_idx));
+  MIR_gen_finish (ctx);
+  MIR_finish (ctx);
+  return 0;
+}

--- a/mir.h
+++ b/mir.h
@@ -485,9 +485,7 @@ static inline MIR_context_t MIR_init2 (MIR_alloc_t alloc, MIR_code_alloc_t code_
 }
 
 /* ...or this one. */
-static inline MIR_context_t MIR_init (void) {
-  return MIR_init2 (NULL, NULL);
-}
+static inline MIR_context_t MIR_init (void) { return MIR_init2 (NULL, NULL); }
 
 extern void MIR_finish (MIR_context_t ctx);
 
@@ -731,6 +729,8 @@ extern void _MIR_dump_code (const char *name, uint8_t *code, size_t code_len);
 
 extern int _MIR_get_hard_reg (MIR_context_t ctx, const char *hard_reg_name);
 extern void *_MIR_get_module_global_var_hard_regs (MIR_context_t ctx, MIR_module_t module);
+extern void *_MIR_get_helpers_bitset (MIR_context_t ctx);
+extern int _MIR_helper_num (MIR_context_t ctx, const char *name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Track runtime helper function usage in a bitmap and expose helper lookup utilities
- Skip emitting unused helper imports when writing MIR modules
- Add test verifying helper bitmap behavior

## Testing
- `make test` *(failed: interrupted during c2mir-interp-test)*

------
https://chatgpt.com/codex/tasks/task_e_6893de14347c8326889c6f2a65c64a5a