### PR TITLE
basic: allow dumping JIT code

### DIFF
--- a/examples/basic/repl-code.out
+++ b/examples/basic/repl-code.out
@@ -1,0 +1,4 @@
+READY.
+READY.
+repl-code.bin
+READY.

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -58,3 +58,10 @@ printf 'LOAD %s\nRUN\nQUIT\n' "$ROOT/examples/basic/hello.bas" | "$BASICC" > "$R
 diff "$ROOT/examples/basic/repl-load.out" "$ROOT/basic/repl-load.out"
 echo "repl LOAD done"
 
+echo "Running repl CODE"
+printf '10 PRINT "HI"\nCOMPILE CODE repl-code.bin\nQUIT\n' | "$BASICC" > "$ROOT/basic/repl-code.out"
+diff "$ROOT/examples/basic/repl-code.out" "$ROOT/basic/repl-code.out"
+test -s repl-code.bin
+rm -f repl-code.bin
+echo "repl CODE done"
+


### PR DESCRIPTION
## Summary
- extend BASIC generator with ability to dump JIT-compiled machine code
- add `COMPILE CODE` command to BASIC REPL
- test dumping machine code via new REPL command

## Testing
- `make basic-test`
- `printf '10 PRINT "HI"\nCOMPILE CODE repl-code.bin\nQUIT\n' | ./basic/basicc`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_689450d76af483269fd934fc4a1b4b64