### PR TITLE
Fix REPL COMPILE CODE output and add test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -451,6 +451,10 @@ basic-test: $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) 
 	diff $(SRC_DIR)/examples/basic/repl.out $(BUILD_DIR)/basic/repl.out
 	printf 'LOAD $(SRC_DIR)/examples/basic/hello.bas\nRUN\nQUIT\n' | $(BUILD_DIR)/basic/basicc$(EXE) > $(BUILD_DIR)/basic/repl-load.out
 	diff $(SRC_DIR)/examples/basic/repl-load.out $(BUILD_DIR)/basic/repl-load.out
+	(cd $(BUILD_DIR)/basic && printf '10 PRINT "HI"\nCOMPILE CODE repl-code.bin\nQUIT\n' | ./basicc$(EXE) > repl-code.out)
+	diff $(SRC_DIR)/examples/basic/repl-code.out $(BUILD_DIR)/basic/repl-code.out
+	test -s $(BUILD_DIR)/basic/repl-code.bin
+	rm -f $(BUILD_DIR)/basic/repl-code.bin
 	printf '10 PRINT "HELLO"\nSAVE $(BUILD_DIR)/basic/repl-save$(EXE)\nQUIT\n' | $(BUILD_DIR)/basic/basicc$(EXE) > $(BUILD_DIR)/basic/repl-save.log
 	test -f $(BUILD_DIR)/basic/repl-save$(EXE)
 	$(BUILD_DIR)/basic/repl-save$(EXE) > $(BUILD_DIR)/basic/repl-save.out

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3999,8 +3999,8 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
     MIR_load_module (ctx, module);
     MIR_gen_init (ctx);
     MIR_link (ctx, MIR_set_gen_interface, resolve);
-    uint8_t *start = _MIR_get_new_code_addr (ctx, 0);
     MIR_gen (ctx, func);
+    uint8_t *start = func->addr;
     uint8_t *end = _MIR_get_new_code_addr (ctx, 0);
     size_t len = end - start;
     FILE *f = fopen (out_name, "wb");


### PR DESCRIPTION
## Summary
- Generate code before capturing code buffer when saving machine code with REPL's COMPILE CODE command
- Add regression test to `basic-test` to ensure `COMPILE CODE` produces a non-empty file

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_68945a22d3e48326a70dc7522eb796b5