### PR TITLE
Avoid upper bound in RND

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -361,7 +361,9 @@ double basic_rnd (double n) {
     srand ((unsigned) time (NULL));
     seeded = 1;
   }
-  return ((double) rand () / RAND_MAX) * n;
+  /* rand () can return RAND_MAX, which would make the result equal to n.
+     Scale by RAND_MAX + 1.0 to keep the value in [0, n). */
+  return ((double) rand () / ((double) RAND_MAX + 1.0)) * n;
 }
 
 double basic_abs (double x) { return fabs (x); }


### PR DESCRIPTION
## Summary
- prevent `basic_rnd` from returning the upper bound by scaling with `RAND_MAX + 1`

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`

------
https://chatgpt.com/codex/tasks/task_e_68966b7ce3b88326bfba8780e2967aa6