### PR TITLE
Add line vector destroy

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -756,6 +756,13 @@ static void line_vec_clear (LineVec *v) {
   v->len = 0;
 }
 
+static void line_vec_destroy (LineVec *v) {
+  line_vec_clear (v);
+  free (v->data);
+  v->data = NULL;
+  v->cap = 0;
+}
+
 static void insert_or_replace_line (LineVec *prog, Line l) {
   if (prog->len == prog->cap) {
     prog->cap = prog->cap ? 2 * prog->cap : 16;
@@ -4228,7 +4235,7 @@ static void repl (void) {
       if (*p == '\0') {
         fprintf (stderr, "missing input file\n");
       } else {
-        line_vec_clear (&prog);
+        line_vec_destroy (&prog);
         load_program (&prog, p);
       }
       continue;
@@ -4238,7 +4245,7 @@ static void repl (void) {
       continue;
     }
     if (strcasecmp (p, "NEW") == 0) {
-      line_vec_clear (&prog);
+      line_vec_destroy (&prog);
       func_vec_clear (&func_defs);
       continue;
     }


### PR DESCRIPTION
## Summary
- ensure REPL cleanup frees program storage by introducing `line_vec_destroy`
- invoke `line_vec_destroy` for `LOAD` and `NEW` operations

## Testing
- `make -j1 basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_689678cbfcf88326a597675b23a107cf