### PR TITLE
docs: describe BASIC dialect syntax

### DIFF
--- a/dialect_syntax.md
+++ b/dialect_syntax.md
@@ -1,0 +1,14 @@
+# BASIC Dialect Syntax
+
+Supported BASIC instructions now include:
+
+- `REM` comments.
+- loops (`FOR`/`NEXT`, `WHILE`/`WEND`).
+- arrays via `DIM` and indexed variables.
+- `DATA`, `READ`, and `RESTORE` statements.
+- graphics commands such as `HOME`, `VTAB`, `HTAB`, `TEXT`, `INVERSE`, `NORMAL`, `HGR2`, `HCOLOR=`, and `HPLOT`.
+- memory and spacing operations like `PEEK`, `POKE`, and `SPC`.
+- integer arithmetic: division (`\`) and modulo (`MOD`).
+- input with `INPUT` and single-character `GET`.
+- state reset via `CLEAR`.
+- multi-way branching with `ON...GOTO` and `ON...GOSUB`.


### PR DESCRIPTION
## Summary
- add BASIC dialect syntax document

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6898bf0ef17883268edf8ded80b668f6