### PR TITLE
docs: note long double precision limits

### DIFF
--- a/examples/basic/README
+++ b/examples/basic/README
@@ -69,3 +69,11 @@ DIGITS?
 3.14159265358979323846
 ```
 
+Floating-Point Precision
+------------------------
+Programs such as `pi.bas` use the host's `long double` type for calculations.
+On x86-64, `long double` typically offers only about 19–20 decimal digits of
+precision, so requesting more digits will not produce additional accurate
+output. Users needing greater precision should compile the BASIC runtime with
+`BASIC_USE_FLOAT128` or link against an arbitrary-precision library.
+


### PR DESCRIPTION
## Summary
- clarify that `long double` on x86-64 only provides ~19–20 decimal digits
- advise using `BASIC_USE_FLOAT128` or arbitrary-precision libraries for higher accuracy

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6898d04b421c832692ec4696831fa870