### PR TITLE
Handle opcode names case-insensitively in BASIC runtime

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <math.h>
 #include <stdint.h>
@@ -823,7 +824,7 @@ double basic_mir_emit (double func_h, const char *op, double a, double b, double
   MIR_context_t ctx = h->ctx;
   MIR_insn_code_t code;
   for (code = 0; code < MIR_INSN_BOUND; code++)
-    if (strcmp (op, MIR_insn_name (ctx, code)) == 0) break;
+    if (strcasecmp (op, MIR_insn_name (ctx, code)) == 0) break;
   if (code >= MIR_INSN_BOUND) return 0.0;
   double vals[3] = {a, b, c};
   MIR_op_t ops[3];


### PR DESCRIPTION
## Summary
- Allow BASIC `MIREMIT` to accept MIR opcodes regardless of case by comparing names with `strcasecmp`
- Include `<strings.h>` for case-insensitive opcode matching

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`
- `./basic/basicc examples/basic/mir_demo.bas`


------
https://chatgpt.com/codex/tasks/task_e_6898d010d3288326b129ce27cebef25a