### PR TITLE
Fix basic-test recipe syntax

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -519,7 +519,7 @@ basic-test: $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $
 	$(BUILD_DIR)/basic/basicc$(EXE) -r -o $(BUILD_DIR)/basic/hello $(SRC_DIR)/examples/basic/hello.bas
 	test -f $(BUILD_DIR)/basic/hello.bmir
 	
-  MIR_LIB_DIRS=$(BUILD_DIR)/basic MIR_LIBS=basic_runtime $(BUILD_DIR)/mir-bin-run$(EXE) $(BUILD_DIR)/basic/hello.bmir hello > $(BUILD_DIR)/basic/hello-run.out
+	MIR_LIB_DIRS=$(BUILD_DIR)/basic MIR_LIBS=basic_runtime $(BUILD_DIR)/mir-bin-run$(EXE) $(BUILD_DIR)/basic/hello.bmir hello > $(BUILD_DIR)/basic/hello-run.out
 	diff $(SRC_DIR)/examples/basic/hello.out $(BUILD_DIR)/basic/hello-run.out
 	$(BUILD_DIR)/basic/basicc-ld$(EXE) $(SRC_DIR)/examples/basic/hello.bas > $(BUILD_DIR)/basic/hello-ld.out
 	diff $(SRC_DIR)/examples/basic/hello.out $(BUILD_DIR)/basic/hello-ld.out


### PR DESCRIPTION
## Summary
- Fix indentation in `basic-test` to ensure Make can execute `mir-bin-run`

## Testing
- `make clean-basic`
- `make`
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_6898d193a424832687c2ff8a5574b5c1