### PR TITLE
Document DATE functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
   - memory and spacing operations like `PEEK`, `POKE`, and `SPC`.
   - integer arithmetic: division (`\\`) and modulo (`MOD`).
   - input with `INPUT` and single-character `GET`.
+  - date retrieval with `DATE` and `DATE$`.
   - state reset via `CLEAR`.
   - multi-way branching with `ON...GOTO` and `ON...GOSUB`.
 

--- a/examples/basic/README
+++ b/examples/basic/README
@@ -54,6 +54,21 @@ Example:
 
 This program builds a function that adds its two arguments and prints `5`.
 
+DATE$ Example
+-------------
+The `DATE$` function returns the current date in `YYYY-MM-DD` format. The
+components can be extracted with `MID$` and converted with `VAL`:
+
+```
+10 d$ = DATE$
+20 y = VAL(MID$(d$, 1, 4))
+30 m = VAL(MID$(d$, 6, 2))
+40 d = VAL(MID$(d$, 9, 2))
+50 PRINT y; "/"; m; "/"; d
+```
+
+This program prints the year, month, and day as numbers.
+
 Pi Spigot Example
 -----------------
 The `pi_spigot.bas` program demonstrates generating digits of `PI` using only


### PR DESCRIPTION
## Summary
- note DATE/DATE$ in supported BASIC instructions
- add README snippet showing how to call DATE$ and parse year, month, and day

## Testing
- `make basic-test` *(fails: GNUmakefile:523: recipe commences before first target)*
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out` *(fails: bash: basic/periodic.out: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898d1bf2ff48326bb3e4f863afac700