### PR TITLE
basic: remove float128 guard

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3,7 +3,7 @@
 #include "basic_runtime.h"
 #include "basic_num.h"
 
-#if defined(BASIC_USE_LONG_DOUBLE) || defined(BASIC_USE_FLOAT128)
+#if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_T_D MIR_T_LD
 #define MIR_new_double_op MIR_new_ldouble_op
 #define MIR_D2I MIR_LD2I


### PR DESCRIPTION
## Summary
- drop BASIC_USE_FLOAT128 from basic compiler conditional, leaving only BASIC_USE_LONG_DOUBLE

## Testing
- `clang-format -i examples/basic/basicc.c`
- `make basic-test` *(fails: `run_test` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898df35a3708326b5390b854a180676