### PR TITLE
examples/basic: remove float128 variant from run-tests

### DIFF
--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -4,14 +4,13 @@ set -eu
 ROOT="$(cd "$(dirname "$0")/../../" && pwd)"
 
 # Determine BASIC compiler binaries to test. If none are supplied as arguments,
-# test the double, long double, and float128 variants built by the makefile.
+# test the double and long double variants built by the makefile.
 if [ "$#" -gt 0 ]; then
         BASICCS=("$@")
 else
         BASICCS=(
                 "$ROOT/basic/basicc"
                 "$ROOT/basic/basicc-ld"
-                "$ROOT/basic/basicc-f128"
         )
 fi
 


### PR DESCRIPTION
## Summary
- limit BASIC test script to double and long double compilers
- drop obsolete float128 references

## Testing
- `make basic-test` *(fails: ./examples/basic/run-tests.sh: line 77: run_test: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898df3dacb08326a2271195881c7fe9