### PR TITLE
Remove float128 support from BASIC numeric macros

### DIFF
--- a/examples/basic/basic_num.h
+++ b/examples/basic/basic_num.h
@@ -16,22 +16,6 @@ typedef long double basic_num_t;
 #define BASIC_LOG logl
 #define BASIC_EXP expl
 #define BASIC_FLOOR floorl
-#elif defined(BASIC_USE_FLOAT128)
-#include <quadmath.h>
-typedef __float128 basic_num_t;
-#define BASIC_NUM_SCANF "%Qg"
-#define BASIC_NUM_PRINTF "%.33Qg"
-#define BASIC_SNPRINTF quadmath_snprintf
-#define BASIC_STRTOF strtoflt128
-#define BASIC_FABS fabsq
-#define BASIC_SQRT sqrtq
-#define BASIC_SIN sinq
-#define BASIC_COS cosq
-#define BASIC_TAN tanq
-#define BASIC_ATAN atanq
-#define BASIC_LOG logq
-#define BASIC_EXP expq
-#define BASIC_FLOOR floorq
 #else
 typedef double basic_num_t;
 #define BASIC_NUM_SCANF "%lf"


### PR DESCRIPTION
## Summary
- drop `BASIC_USE_FLOAT128` branch and related quadmath macros from `basic_num.h`
- retain only long double and double numeric paths

## Testing
- `make basic-test` *(fails: ./examples/basic/run-tests.sh: line 78: run_test: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898df35874083269f3a7f7b73fc3fc9