### PR TITLE
Remove float128 BASIC build rules

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -403,17 +403,14 @@ clean-mir-utility-tests:
 ifeq ($(OS),Windows_NT)
   BASIC_RUNTIME_LIB=basic_runtime.dll
   BASIC_RUNTIME_LIB_LD=basic_runtime_ld.dll
-  BASIC_RUNTIME_LIB_F128=basic_runtime_f128.dll
   BASIC_RUNTIME_FLAGS=-shared
 else ifeq ($(UNAME_S),Darwin)
   BASIC_RUNTIME_LIB=libbasic_runtime.dylib
   BASIC_RUNTIME_LIB_LD=libbasic_runtime_ld.dylib
-  BASIC_RUNTIME_LIB_F128=libbasic_runtime_f128.dylib
   BASIC_RUNTIME_FLAGS=-dynamiclib
 else
   BASIC_RUNTIME_LIB=libbasic_runtime.so
   BASIC_RUNTIME_LIB_LD=libbasic_runtime_ld.so
-  BASIC_RUNTIME_LIB_F128=libbasic_runtime_f128.so
   BASIC_RUNTIME_FLAGS=-shared
 endif
 
@@ -424,22 +421,12 @@ $(BUILD_DIR)/basic/basicc_ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir
 	$(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
 	$(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE $^ -lm $(EXEO)$@
 
-$(BUILD_DIR)/basic/basicc_f128$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-	$(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
-	$(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FLOAT128 $^ -lm -lquadmath $(EXEO)$@
-
 
 $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
 	$(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
 	$(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c
 	mkdir -p $(BUILD_DIR)/basic
 	$(COMPILE_AND_LINK) -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm $(EXEO)$@
-
-$(BUILD_DIR)/basic/basicc-f128$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-	$(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
-	$(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c
-	mkdir -p $(BUILD_DIR)/basic
-	$(COMPILE_AND_LINK) -DBASIC_USE_FLOAT128 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm -lquadmath $(EXEO)$@
 
 $(BUILD_DIR)/basic/kitty_test$(EXE): \
 	$(SRC_DIR)/examples/basic/kitty/kitty_test.c \
@@ -462,17 +449,9 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DBASIC_USE_LONG_DOUBLE $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
-$(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_F128): \
-        $(SRC_DIR)/examples/basic/basic_runtime.c \
-        $(SRC_DIR)/examples/basic/kitty/kitty.c \
-        $(SRC_DIR)/examples/basic/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DBASIC_USE_FLOAT128 $(BASIC_RUNTIME_FLAGS) $^ -lm -lquadmath $(EXEO)$@
-
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/basicc-f128$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_F128) $(BUILD_DIR)/mir-bin-run$(EXE)
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
 	$(SRC_DIR)/examples/basic/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/examples/basic/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
-	$(SRC_DIR)/examples/basic/run-tests.sh $(BUILD_DIR)/basic/basicc-f128$(EXE)
 
 # ------------------ MIR interp tests --------------------------
 .PHONY: clean-mir-interp-tests


### PR DESCRIPTION
## Summary
- drop float128 runtime and compiler variants from BASIC example
- clean up BASIC test prerequisites after removing float128 support

## Testing
- `make basic-test` *(fails: examples/basic/run-tests.sh line 78: run_test: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898df3ffdb48326beb26aa362011c43