### PR TITLE
Remove mandelbrot from BASIC test suite

### DIFF
--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -63,7 +63,7 @@ PY
                 fi
         }
 
-        for t in hello relop adder string strfuncs instr gosub funcproc graphics readhplot circle box sudoku array_oob_read array_oob_write dim_expr mandelbrot pi baseconv mir_demo datediff date rnd_noarg; do
+        for t in hello relop adder string strfuncs instr gosub funcproc graphics readhplot circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date rnd_noarg; do
                 echo "Running $t"
                 run_test "$t"
                 echo "$t OK"


### PR DESCRIPTION
## Summary
- drop mandelbrot example from the run-tests script's test list

## Testing
- `make basic-test` *(fails: dim expression should have failed)*
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_68991d8e3d9c83268e6afef0389bd456