### PR TITLE
Use GET for single-key input in Logotron example

### DIFF
--- a/examples/basic/logotron.bas
+++ b/examples/basic/logotron.bas
@@ -18,7 +18,7 @@
 180 PRINT "Appuyez sur ENTREE pour generer un mot."
 190 PRINT "Tapez Q puis ENTREE pour quitter."
 200 PRINT
-210 INPUT "", R$
+210 GET R$
 220 IF R$ = "Q" OR R$ = "q" THEN END
 230 REM TIRAGE ALEATOIRE D'UN COUPLE PREFIXE/SENS
 240 I = INT(RND * NP) * 2 + 1


### PR DESCRIPTION
## Summary
- replace INPUT with GET in examples/basic/logotron.bas so pressing Enter alone generates a word

## Testing
- `make basic-test` *(fails: see log for `make: *** [GNUmakefile:456: basic-test] Error 1`)*
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_68991dbed4848326a5661ebf77d203bf