### PR TITLE
Fix BASIC REPL cleanup order

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -4747,6 +4747,8 @@ static void repl (void) {
       if (*s == '\0') {
         fprintf (stderr, "missing input file\n");
       } else {
+        func_vec_clear (&func_defs);
+        data_vals_clear ();
         line_vec_destroy (&prog);
         load_program (&prog, s);
       }
@@ -4757,20 +4759,18 @@ static void repl (void) {
       continue;
     }
     if (strcasecmp (s, "NEW") == 0) {
-      line_vec_destroy (&prog);
       func_vec_clear (&func_defs);
       data_vals_clear ();
+      line_vec_destroy (&prog);
       continue;
     }
     if (strcasecmp (s, "QUIT") == 0 || strcasecmp (s, "EXIT") == 0) {
       break;
     }
   }
-  line_vec_clear (&prog);
-  free (prog.data);
   func_vec_clear (&func_defs);
-  free (func_defs.data);
   data_vals_clear ();
+  line_vec_destroy (&prog);
 }
 
 int main (int argc, char **argv) {


### PR DESCRIPTION
## Summary
- ensure function definitions and data values are cleared before destroying program lines in REPL
- streamline final cleanup by removing redundant free and using `line_vec_destroy`

## Testing
- `make basic-test` *(fails: malloc_consolidate(): invalid chunk size)*
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`

------
https://chatgpt.com/codex/tasks/task_e_68992543cd248326a2254f67d4d10064