### PR TITLE
Fix buffer overflow in BASIC runtime name generation

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -790,8 +790,9 @@ double basic_mir_func (double mod_h, const char *name, double nargs_d) {
   MIR_type_t res = MIR_T_D;
   MIR_var_t *vars = nargs ? malloc (nargs * sizeof (MIR_var_t)) : NULL;
   for (size_t i = 0; i < nargs; i++) {
-    char *arg_name = malloc (16);
-    sprintf (arg_name, "a%zu", i);
+    size_t len = snprintf (NULL, 0, "a%zu", i) + 1;
+    char *arg_name = malloc (len);
+    snprintf (arg_name, len, "a%zu", i);
     vars[i].type = MIR_T_D;
     vars[i].name = arg_name;
   }
@@ -811,8 +812,9 @@ double basic_mir_reg (double func_h) {
   MIR_context_t ctx = h->ctx;
   MIR_reg_t r;
   if (fh->next_arg < fh->nargs) {
-    char name[16];
-    sprintf (name, "a%zu", fh->next_arg++);
+    size_t len = snprintf (NULL, 0, "a%zu", fh->next_arg) + 1;
+    char *name = malloc (len);
+    snprintf (name, len, "a%zu", fh->next_arg++);
     r = MIR_reg (ctx, name, fh->item->u.func);
   } else {
     r = MIR_new_func_reg (ctx, fh->item->u.func, MIR_T_D, NULL);


### PR DESCRIPTION
## Summary
- ensure generated argument and register names allocate enough space using snprintf

## Testing
- `make basic-test` *(fails: malloc_consolidate(): invalid chunk size)*

------
https://chatgpt.com/codex/tasks/task_e_689928a17fdc8326bcfa01debe52b9fc