### PR TITLE
Fix long double BASIC runtime memory and MIR helpers

### DIFF
--- a/examples/basic/basic_runtime.h
+++ b/examples/basic/basic_runtime.h
@@ -1,18 +1,21 @@
 #ifndef BASIC_RUNTIME_H
 #define BASIC_RUNTIME_H
+#include "basic_num.h"
 #include "mir.h"
 #include "mir-gen.h"
 
-double basic_mir_ctx (void);
-double basic_mir_mod (double ctx, const char *name);
-double basic_mir_func (double mod, const char *name, double nargs);
-double basic_mir_reg (double func);
-double basic_mir_label (double func);
-double basic_mir_emit (double func, const char *op, double a, double b, double c);
-double basic_mir_emitlbl (double func, double label);
-double basic_mir_ret (double func, double reg);
-double basic_mir_finish (double mod);
-double basic_mir_run (double func, double a1, double a2, double a3, double a4);
-double basic_mir_dump (double func);
+basic_num_t basic_mir_ctx (void);
+basic_num_t basic_mir_mod (basic_num_t ctx, const char *name);
+basic_num_t basic_mir_func (basic_num_t mod, const char *name, basic_num_t nargs);
+basic_num_t basic_mir_reg (basic_num_t func);
+basic_num_t basic_mir_label (basic_num_t func);
+basic_num_t basic_mir_emit (basic_num_t func, const char *op, basic_num_t a, basic_num_t b,
+                            basic_num_t c);
+basic_num_t basic_mir_emitlbl (basic_num_t func, basic_num_t label);
+basic_num_t basic_mir_ret (basic_num_t func, basic_num_t reg);
+basic_num_t basic_mir_finish (basic_num_t mod);
+basic_num_t basic_mir_run (basic_num_t func, basic_num_t a1, basic_num_t a2, basic_num_t a3,
+                           basic_num_t a4);
+basic_num_t basic_mir_dump (basic_num_t func);
 
 #endif /* BASIC_RUNTIME_H */

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2659,7 +2659,8 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       MIR_reg_t off = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       MIR_append_insn (ctx, func,
                        MIR_new_insn (ctx, MIR_MUL, MIR_new_reg_op (ctx, off),
-                                     MIR_new_reg_op (ctx, idx), MIR_new_int_op (ctx, 8)));
+                                     MIR_new_reg_op (ctx, idx),
+                                     MIR_new_int_op (ctx, sizeof (basic_num_t))));
       sprintf (buf, "$t%d", tmp_id++);
       MIR_reg_t addr = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       MIR_append_insn (ctx, func,
@@ -3397,9 +3398,11 @@ static void gen_stmt (Stmt *s) {
         }
         sprintf (buf, "$t%d", tmp_id++);
         MIR_reg_t off = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+        size_t elem_size = v->is_str ? sizeof (char *) : sizeof (basic_num_t);
         MIR_append_insn (g_ctx, g_func,
                          MIR_new_insn (g_ctx, MIR_MUL, MIR_new_reg_op (g_ctx, off),
-                                       MIR_new_reg_op (g_ctx, idx), MIR_new_int_op (g_ctx, 8)));
+                                       MIR_new_reg_op (g_ctx, idx),
+                                       MIR_new_int_op (g_ctx, elem_size)));
         sprintf (buf, "$t%d", tmp_id++);
         MIR_reg_t addr = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
         MIR_append_insn (g_ctx, g_func,
@@ -3587,9 +3590,11 @@ static void gen_stmt (Stmt *s) {
                                        MIR_new_reg_op (g_ctx, idx), MIR_new_int_op (g_ctx, asize)));
       sprintf (buf, "$t%d", tmp_id++);
       MIR_reg_t off = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+      size_t elem_size = s->u.let.is_str ? sizeof (char *) : sizeof (basic_num_t);
       MIR_append_insn (g_ctx, g_func,
                        MIR_new_insn (g_ctx, MIR_MUL, MIR_new_reg_op (g_ctx, off),
-                                     MIR_new_reg_op (g_ctx, idx), MIR_new_int_op (g_ctx, 8)));
+                                     MIR_new_reg_op (g_ctx, idx),
+                                     MIR_new_int_op (g_ctx, elem_size)));
       sprintf (buf, "$t%d", tmp_id++);
       MIR_reg_t addr = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
       MIR_append_insn (g_ctx, g_func,
@@ -4120,12 +4125,13 @@ static void gen_stmt (Stmt *s) {
                                        MIR_new_reg_op (g_ctx, total),
                                        MIR_new_reg_op (g_ctx, size2)));
       }
+      size_t elem_size = s->u.dim.is_str[k] ? sizeof (char *) : sizeof (basic_num_t);
       MIR_append_insn (g_ctx, g_func,
                        MIR_new_call_insn (g_ctx, 5, MIR_new_ref_op (g_ctx, calloc_proto),
                                           MIR_new_ref_op (g_ctx, calloc_import),
                                           MIR_new_reg_op (g_ctx, base),
                                           MIR_new_reg_op (g_ctx, total),
-                                          MIR_new_int_op (g_ctx, 8)));
+                                          MIR_new_int_op (g_ctx, elem_size)));
     }
     break;
   }
@@ -4516,10 +4522,12 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   for (size_t i = 0; i < g_vars.len; i++)
     if (g_vars.data[i].is_array && g_vars.data[i].size <= 1) {
       g_vars.data[i].size = 11;
+      size_t elem_size = g_vars.data[i].is_str ? sizeof (char *) : sizeof (basic_num_t);
       MIR_insn_t call = MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, calloc_proto),
                                            MIR_new_ref_op (ctx, calloc_import),
                                            MIR_new_reg_op (ctx, g_vars.data[i].reg),
-                                           MIR_new_int_op (ctx, 11), MIR_new_int_op (ctx, 8));
+                                           MIR_new_int_op (ctx, 11),
+                                           MIR_new_int_op (ctx, elem_size));
       MIR_insert_insn_after (ctx, func, g_var_init_anchor, call);
       g_var_init_anchor = call;
     }


### PR DESCRIPTION
## Summary
- allocate BASIC numeric arrays using the actual `basic_num_t` size
- switch MIR helper APIs to `basic_num_t` and translate D* ops to LD* under long double

## Testing
- `examples/basic/run-tests.sh ./basic/basicc`
- `examples/basic/run-tests.sh ./basic/basicc-ld`


------
https://chatgpt.com/codex/tasks/task_e_68998e7f23c0832694a5cafe43cf3bb5