### PR TITLE
Add test for PRINT expression errors

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -1478,7 +1478,11 @@ static Node *parse_logical (Parser *p) {
   return n;
 }
 
-static Node *parse_expr (Parser *p) { return parse_logical (p); }
+static Node *parse_expr (Parser *p) {
+  Node *n = parse_logical (p);
+  p->has_peek = 0;
+  return n;
+}
 
 static int parse_if_part (Parser *p, StmtVec *vec, int stop_on_else);
 

--- a/examples/basic/print_expr_error.bas
+++ b/examples/basic/print_expr_error.bas
@@ -1,0 +1,3 @@
+5 REM print expression error
+10 PRINT +
+20 END

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -97,6 +97,15 @@ fi
 grep -q "expected integer" "$ROOT/basic/dim_expr_error.err"
 echo "dim expression error OK"
 
+echo "Running print expression (expect error)"
+"$BASICC" "$ROOT/examples/basic/print_expr_error.bas" >/dev/null \
+        2> "$ROOT/basic/print_expr_error.err" || true
+if ! grep -q "parse error at line 10" "$ROOT/basic/print_expr_error.err"; then
+        echo "print expression should have failed"
+        exit 1
+fi
+echo "print expression error OK"
+
         echo "Running repl LOAD"
         printf 'LOAD %s\nRUN\nQUIT\n' "$ROOT/examples/basic/hello.bas" | "$BASICC" > "$ROOT/basic/repl-load.out"
         diff "$ROOT/examples/basic/repl-load.out" "$ROOT/basic/repl-load.out"


### PR DESCRIPTION
## Summary
- reset parser lookahead after evaluating expression to avoid stale peek
- add regression test for PRINT expressions with missing operands

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_6899aa2c97ec8326bf5933003134204f