### PR TITLE
Validate integer line numbers in BASIC parser

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2350,7 +2350,13 @@ static int parse_line (Parser *p, char *line, Line *out) {
   skip_ws (p);
   Token t = peek_token (p);
   int line_no = 0;
-  if (t.type == TOK_NUMBER) line_no = (int) parse_number (p);
+  if (t.type == TOK_NUMBER) {
+    if ((basic_num_t) (int) t.num != t.num) {
+      fprintf (stderr, "expected integer\n");
+      return parse_error (p);
+    }
+    line_no = (int) parse_number (p);
+  }
   p->line_no = line_no;
   out->line = line_no;
   out->stmts = (StmtVec) {0};


### PR DESCRIPTION
## Summary
- ensure BASIC line numbers are integers before parsing

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6899ba6c445883269d532866c69faef9