### PR TITLE
Fix duplicate token enum entries in BASIC compiler

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -975,8 +975,6 @@ typedef enum {
   TOK_ERROR,
   TOK_RESUME,
   TOK_CALL,
-  TOK_SUB,
-  TOK_FUNCTION,
   TOK_AND,
   TOK_OR,
   TOK_NOT,


### PR DESCRIPTION
## Summary
- remove duplicate TOK_FUNCTION and TOK_SUB entries from token enum in `examples/basic/basicc.c`
- keep enumeration order consistent with keyword table

## Testing
- `make basic-test`
- `./basic/basicc examples/basic/periodic.bas > basic/periodic.out && diff examples/basic/periodic.out basic/periodic.out`


------
https://chatgpt.com/codex/tasks/task_e_6899e65ab5e88326892814390580cd8f