### PR TITLE
Handle strdup failure in parse_line

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2368,6 +2368,10 @@ static int parse_line (Parser *p, char *line, Line *out) {
   p->tok.type = TOK_EOF;
   p->line_start = line;
   out->src = strdup (line);
+  if (out->src == NULL) {
+    fprintf (stderr, "out of memory\n");
+    return parse_error (p);
+  }
   Token t = peek_token (p);
   int line_no = 0;
   if (t.type == TOK_NUMBER) {


### PR DESCRIPTION
## Summary
- Abort BASIC line parsing if strdup fails to allocate memory

## Testing
- `gcc -Wall -Wextra -fsyntax-only -I. examples/basic/basicc.c`
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689a63c607b483269ad2b94da990bc2d