### PR TITLE
basicc: handle null parameter names

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2474,6 +2474,10 @@ static void parse_func (Parser *p, FILE *f, char *line, int is_sub) {
     if (peek_token (p).type != TOK_RPAREN) {
       while (1) {
         char *param = parse_id (p);
+        if (param == NULL) {
+          parse_error (p);
+          return;
+        }
         int ps = param[strlen (param) - 1] == '$';
         if (n == cap) {
           cap = cap ? 2 * cap : 4;


### PR DESCRIPTION
## Summary
- guard against NULL from `parse_id` when collecting BASIC function parameters

## Testing
- `gcc -Wall -Wextra -fsyntax-only examples/basic/basicc.c` *(fails: mir.h missing)*
- `gcc -I. -Wall -Wextra -fsyntax-only examples/basic/basicc.c`
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689a63c874608326975df487515d904c