### PR TITLE
Enable extra warnings for BASIC builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ ifeq ($(OS),Windows_NT)
     endif
   endif
   ifeq ($(CC),gcc)
-    CFLAGS += -fPIC -g -std=gnu11 -Wno-abi -fsigned-char
+    CFLAGS += -fPIC -g -std=gnu11 -Wno-abi -fsigned-char -Wall -Wextra
     CFLAGS += -fno-tree-sra
     COPTFLAGS = -O3 -DNDEBUG
     CDEBFLAGS =
@@ -58,7 +58,7 @@ ifeq ($(OS),Windows_NT)
 else
   EXE=
   CC=gcc
-  CFLAGS += -fPIC -g -std=gnu11 -Wno-abi -fsigned-char
+  CFLAGS += -fPIC -g -std=gnu11 -Wno-abi -fsigned-char -Wall -Wextra
   ifneq ($(ADDITIONAL_INCLUDE_PATH),)
     CFLAGS += -DADDITIONAL_INCLUDE_PATH=\"$(ADDITIONAL_INCLUDE_PATH)\"
   endif

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -72,10 +72,10 @@ PY
 
         echo "Building extlib"
         if [[ "$BASICC" == *-ld ]]; then
-                cc -shared -fPIC -DBASIC_USE_LONG_DOUBLE -I"$ROOT/examples/basic" \
+                cc -shared -fPIC -Wall -Wextra -DBASIC_USE_LONG_DOUBLE -I"$ROOT/examples/basic" \
                         "$ROOT/examples/basic/extlib.c" -o "$ROOT/basic/libextlib.so"
         else
-                cc -shared -fPIC -I"$ROOT/examples/basic" \
+                cc -shared -fPIC -Wall -Wextra -I"$ROOT/examples/basic" \
                         "$ROOT/examples/basic/extlib.c" -o "$ROOT/basic/libextlib.so"
         fi
         echo "Running extern"


### PR DESCRIPTION
## Summary
- build with `-Wall -Wextra` across all platforms
- compile BASIC runtime tests with extra warnings

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689a6654ec108326be71f909da801e30