### PR TITLE
Handle DATA statements in BASIC compiler

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3710,6 +3710,7 @@ static void gen_stmt (Stmt *s) {
   case ST_PUT: gen_put (s); break;
   case ST_PUT_HASH: gen_put_hash (s); break;
   case ST_POKE: gen_poke (s); break;
+  case ST_DATA: /* DATA values are processed at parse time, no code needed */ break;
   case ST_READ: {
     for (size_t k = 0; k < s->u.read.n; k++) {
       Node *v = s->u.read.vars[k];

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -84,7 +84,7 @@ PY
         diff "$ROOT/examples/basic/extern.out" "$ROOT/basic/extern.out"
         echo "extern OK"
 
-        for t in hello relop adder string strfuncs instr gosub on funcproc graphics hplot_bounds readhplot hgr2reset circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date rnd_noarg hexoct; do
+        for t in hello relop adder string strfuncs instr gosub on funcproc graphics hplot_bounds readhplot restore hgr2reset circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date rnd_noarg hexoct; do
                 echo "Running $t"
                 run_test "$t"
                 echo "$t OK"


### PR DESCRIPTION
## Summary
- Treat DATA statements in code generation so they no longer trigger unhandled switch warnings
- Test DATA/READ/RESTORE flow by adding the existing `restore` program to the BASIC test suite

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689a6b6511348326996b624519ee5ac2