### PR TITLE
basic: include sys/time.h in runtime

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -14,6 +14,7 @@
 #endif
 #include "basic_num.h"
 #include <sys/wait.h>
+#include <sys/time.h>
 #include "kitty/kitty.h"
 #include "basic_runtime.h"
 #if defined(BASIC_USE_LONG_DOUBLE)


### PR DESCRIPTION
## Summary
- include <sys/time.h> in BASIC runtime

## Testing
- `make basic-test` *(fails: redefinition of `basic_screen` in basic_runtime.c)*

------
https://chatgpt.com/codex/tasks/task_e_689a781ee6788326901136a69aa37fe8