### PR TITLE
Expose basic_clear_array in runtime header

### DIFF
--- a/examples/basic/basic_runtime.h
+++ b/examples/basic/basic_runtime.h
@@ -18,4 +18,6 @@ basic_num_t basic_mir_run (basic_num_t func, basic_num_t a1, basic_num_t a2, bas
                            basic_num_t a4);
 basic_num_t basic_mir_dump (basic_num_t func);
 
+void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str);
+
 #endif /* BASIC_RUNTIME_H */

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -65,7 +65,6 @@ extern int basic_strcmp (const char *, const char *);
 extern basic_num_t basic_read (void);
 extern char *basic_read_str (void);
 extern void basic_restore (void);
-extern void basic_clear_array (void *, basic_num_t, basic_num_t);
 extern char *basic_strdup (const char *);
 extern void basic_free (char *);
 


### PR DESCRIPTION
## Summary
- declare `basic_clear_array` in `basic_runtime.h`
- remove redundant extern declaration from `basicc.c`

## Testing
- `make basic-test` *(fails: redefinition of `basic_screen` in basic_runtime.c)*

------
https://chatgpt.com/codex/tasks/task_e_689a7815d9c483268a6f4da22c59de69