### PR TITLE
Remove duplicate screen test

### DIFF
--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -84,7 +84,7 @@ PY
         diff "$ROOT/examples/basic/extern.out" "$ROOT/basic/extern.out"
         echo "extern OK"
 
-        for t in hello relop adder string strfuncs instr gosub on funcproc graphics screen hplot_bounds readhplot restore data_read clear hgr2reset circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date random rnd_noarg hexoct screen; do
+for t in hello relop adder string strfuncs instr gosub on funcproc graphics screen hplot_bounds readhplot restore data_read clear hgr2reset circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date random rnd_noarg hexoct; do
                 echo "Running $t"
                 run_test "$t"
                 echo "$t OK"


### PR DESCRIPTION
## Summary
- deduplicate `screen` entry in BASIC example test list

## Testing
- `make basic-test` *(fails: redefinition of `basic_screen` in examples/basic/basic_runtime.c)*
- `examples/basic/run-tests.sh basic/basicc` *(fails: redefinition of `basic_screen`)*

------
https://chatgpt.com/codex/tasks/task_e_689a78100f0c8326b1aa51278b92e124