### PR TITLE
Handle terminal alt-screen codes in BASIC tests

### DIFF
--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -35,6 +35,8 @@ run_tests() {
                 else
                         "$BASICC" "$src" > "$out"
                 fi
+                # Strip terminal alternate screen sequences to keep diffs stable
+                perl -0 -i -pe 's/\x1b\[\?1049[hl]//g' "$out"
                 if [ "$name" = "circle" ] || [ "$name" = "box" ]; then
                         grep -ao "$(echo "$name" | tr a-z A-Z)" "$out" > "$out.filtered" || true
                         mv "$out.filtered" "$out"


### PR DESCRIPTION
## Summary
- strip `[?1049h`/`[?1049l` sequences from BASIC test outputs to stabilize diffs

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689a7aa3edc083269bd2d9ac427e046e