### PR TITLE
Remove DATA warning in BASIC compiler

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3802,7 +3802,6 @@ static void gen_stmt (Stmt *s) {
   case ST_POKE: gen_poke (s); break;
   case ST_DATA:
     /* DATA values are processed at parse time, no code generation needed */
-    fprintf (stderr, "DATA not implemented\n");
     break;
   case ST_READ: {
     for (size_t k = 0; k < s->u.read.n; k++) {


### PR DESCRIPTION
## Summary
- Drop redundant `fprintf` for `DATA` statements since values are handled during parsing
- Confirm BASIC `DATA` values are initialized before execution

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689a815d958483269e222dfcce86caa7