### PR TITLE
Handle parse failure cleanup in BASIC loader

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2718,6 +2718,7 @@ static int load_program (LineVec *prog, const char *path) {
       insert_or_replace_line (prog, l);
     } else {
       /* error already reported by parse_line */
+      free_line (&l);
       ok = 0;
       break;
     }


### PR DESCRIPTION
## Summary
- Free partially parsed lines in `load_program` on parse errors to avoid leaks

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689a83a6728c8326a258ec1b697e378d