### PR TITLE
Fix token cleanup in BASIC program loader

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -1138,6 +1138,21 @@ typedef struct {
   int line_no;
 } Parser;
 
+static void free_token (Token *t) {
+  if (t->str != NULL) {
+    free (t->str);
+    t->str = NULL;
+  }
+}
+
+static void cleanup_parser (Parser *p) {
+  free_token (&p->tok);
+  if (p->has_peek) {
+    free_token (&p->peek);
+    p->has_peek = 0;
+  }
+}
+
 /* character-level parser state is stored directly in p->cur */
 
 static void report_parse_error_details (int line_no, const char *line, const char *pos) {
@@ -2698,17 +2713,23 @@ static int load_program (LineVec *prog, const char *path) {
     p->cur = line;
     Token t = peek_token (p);
     if (t.type == TOK_EOF) {
-      next_token (p);
+      t = next_token (p);
+      free_token (&t);
+      cleanup_parser (p);
       continue;
     }
     if (t.type == TOK_FUNCTION || t.type == TOK_SUB) {
       t = next_token (p);
-      if (t.str != NULL) free (t.str);
-      parse_func (p, f, line, t.type == TOK_SUB);
+      int is_sub = t.type == TOK_SUB;
+      free_token (&t);
+      cleanup_parser (p);
+      parse_func (p, f, line, is_sub);
+      cleanup_parser (p);
       continue;
     }
     t = next_token (p);
-    if (t.str != NULL) free (t.str);
+    free_token (&t);
+    cleanup_parser (p);
     Line l;
     if (parse_line (p, line, &l)) {
       if (l.line == 0) {
@@ -2716,9 +2737,11 @@ static int load_program (LineVec *prog, const char *path) {
         auto_line += 10;
       }
       insert_or_replace_line (prog, l);
+      cleanup_parser (p);
     } else {
       /* error already reported by parse_line */
       ok = 0;
+      cleanup_parser (p);
       break;
     }
   }


### PR DESCRIPTION
## Summary
- Free tokens in BASIC parser and add parser cleanup helper
- Ensure load_program releases tokens and handles EOF/errors cleanly

## Testing
- `make basic-test` *(fails: EXTERN not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_689a838b449483269eaaf8555061c7da