### PR TITLE
Silently accept extern declarations in BASIC compiler

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3839,8 +3839,7 @@ static void gen_stmt (Stmt *s) {
     safe_fprintf (stderr, "DEF not implemented\n");
     break;
   case ST_EXTERN:
-    /* no code generation needed */
-    safe_fprintf (stderr, "EXTERN not implemented\n");
+    /* extern declarations are handled during parsing */
     break;
   case ST_PRINT: gen_print (s); break;
   case ST_PRINT_HASH: gen_print_hash (s); break;


### PR DESCRIPTION
## Summary
- Handle `EXTERN` statements in BASIC generator without emitting warnings

## Testing
- `make basic-test` *(fails: expected HELLO but got 20 END)*

------
https://chatgpt.com/codex/tasks/task_e_689a8684a6108326af763da7386e0683