### PR TITLE
Suppress EXTERN warning in BASIC codegen

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3840,7 +3840,6 @@ static void gen_stmt (Stmt *s) {
     break;
   case ST_EXTERN:
     /* no code generation needed */
-    safe_fprintf (stderr, "EXTERN not implemented\n");
     break;
   case ST_PRINT: gen_print (s); break;
   case ST_PRINT_HASH: gen_print_hash (s); break;


### PR DESCRIPTION
## Summary
- stop printing misleading "EXTERN not implemented" message from BASIC compiler

## Testing
- `make basic-test` *(fails: hello output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689a86488cb8832685f351e83cb10c50