### PR TITLE
Add basic bump allocator and tests

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -1,0 +1,59 @@
+#include "basic_pool.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  char *data;
+  size_t size;
+  size_t pos;
+} BasicPool;
+
+static BasicPool pool;
+
+static size_t align_up (size_t n) {
+  size_t align = sizeof (void *);
+  return (n + align - 1) & ~(align - 1);
+}
+
+void basic_pool_init (size_t size) {
+  pool.data = size ? malloc (size) : NULL;
+  pool.size = pool.data ? size : 0;
+  pool.pos = 0;
+}
+
+void *basic_pool_alloc (size_t size) {
+  size = align_up (size);
+  if (pool.pos + size > pool.size) {
+    size_t newsize = pool.size ? pool.size : 1024;
+    while (pool.pos + size > newsize) newsize *= 2;
+    char *newdata = realloc (pool.data, newsize);
+    if (newdata == NULL) return NULL;
+    pool.data = newdata;
+    pool.size = newsize;
+  }
+  void *res = pool.data + pool.pos;
+  pool.pos += size;
+  return res;
+}
+
+void basic_pool_reset (void) { pool.pos = 0; }
+
+void basic_pool_destroy (void) {
+  free (pool.data);
+  pool.data = NULL;
+  pool.size = pool.pos = 0;
+}
+
+char *basic_alloc_string (size_t len) {
+  char *s = basic_pool_alloc (len + 1);
+  if (s != NULL) s[len] = '\0';
+  return s;
+}
+
+void *basic_alloc_array (size_t count, size_t elem_size, int clear) {
+  size_t n = count * elem_size;
+  void *p = basic_pool_alloc (n);
+  if (p != NULL && clear) memset (p, 0, n);
+  return p;
+}

--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -1,0 +1,14 @@
+#ifndef BASIC_POOL_H
+#define BASIC_POOL_H
+
+#include <stddef.h>
+
+void basic_pool_init (size_t size);
+void *basic_pool_alloc (size_t size);
+void basic_pool_reset (void);
+void basic_pool_destroy (void);
+
+char *basic_alloc_string (size_t len);
+void *basic_alloc_array (size_t count, size_t elem_size, int clear);
+
+#endif /* BASIC_POOL_H */

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -1,0 +1,24 @@
+#include "basic_pool.h"
+#include <stdio.h>
+#include <string.h>
+
+int main (void) {
+  basic_pool_init (0);
+
+  char *s = basic_alloc_string (5);
+  strcpy (s, "hello");
+  if (strcmp (s, "hello") != 0) return 1;
+
+  int *arr = basic_alloc_array (4, sizeof (int), 1);
+  for (int i = 0; i < 4; ++i)
+    if (arr[i] != 0) return 1;
+
+  basic_pool_reset ();
+  char *s2 = basic_alloc_string (3);
+  strcpy (s2, "bye");
+  if (strcmp (s2, "bye") != 0) return 1;
+
+  basic_pool_destroy ();
+  printf ("basic_pool_test OK\n");
+  return 0;
+}

--- a/examples/basic/basic_pool_test.out
+++ b/examples/basic/basic_pool_test.out
@@ -1,0 +1,1 @@
+basic_pool_test OK

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -94,6 +94,33 @@ PY
         diff "$ROOT/examples/basic/hcolor_test.out" "$ROOT/basic/hcolor_test.out"
         echo "hcolor_test OK"
 
+        echo "Building basic_pool_test"
+        cc -Wall -Wextra -I"$ROOT/examples/basic" \
+                "$ROOT/examples/basic/basic_pool.c" \
+                "$ROOT/examples/basic/basic_pool_test.c" \
+                -o "$ROOT/basic/basic_pool_test"
+        echo "Running basic_pool_test"
+        "$ROOT/basic/basic_pool_test" > "$ROOT/basic/basic_pool_test.out" 2> "$ROOT/basic/basic_pool_test.err"
+        if [ -s "$ROOT/basic/basic_pool_test.err" ]; then
+                echo "Unexpected stderr for basic_pool_test"
+                cat "$ROOT/basic/basic_pool_test.err"
+                exit 1
+        fi
+        rm -f "$ROOT/basic/basic_pool_test.err"
+        diff "$ROOT/examples/basic/basic_pool_test.out" "$ROOT/basic/basic_pool_test.out"
+        echo "basic_pool_test OK"
+
+        echo "Running basic_pool_test"
+        "$ROOT/basic/basic_pool_test" > "$ROOT/basic/basic_pool_test.out" 2> "$ROOT/basic/basic_pool_test.err"
+        if [ -s "$ROOT/basic/basic_pool_test.err" ]; then
+                echo "Unexpected stderr for basic_pool_test"
+                cat "$ROOT/basic/basic_pool_test.err"
+                exit 1
+        fi
+        rm -f "$ROOT/basic/basic_pool_test.err"
+        diff "$ROOT/examples/basic/basic_pool_test.out" "$ROOT/basic/basic_pool_test.out"
+        echo "basic_pool_test OK"
+
         echo "Building extlib"
         if [[ "$BASICC" == *-ld ]]; then
                 cc -shared -fPIC -Wall -Wextra -DBASIC_USE_LONG_DOUBLE -I"$ROOT/examples/basic" \


### PR DESCRIPTION
## Summary
- implement a simple bump allocation pool for BASIC examples
- provide helpers to allocate strings and arrays from the pool
- add a small C test verifying the pool and integrate into BASIC test suite

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689af68d482083268393fe95e6706482