### PR TITLE
Use arena allocator for BASIC AST

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -416,16 +416,19 @@ endif
 
 $(BUILD_DIR)/basic/basicc$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm $(EXEO)$@
 $(BUILD_DIR)/basic/basicc_ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE $^ -lm $(EXEO)$@
 
 
 $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/ryu/ld2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm $(EXEO)$@

--- a/examples/basic/arena.c
+++ b/examples/basic/arena.c
@@ -1,0 +1,53 @@
+#include "arena.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+#define ARENA_DEFAULT_CHUNK_SIZE 4096
+
+void arena_init (arena_t *a) { a->head = NULL; }
+
+static arena_chunk_t *new_chunk (size_t size) {
+  arena_chunk_t *c = malloc (sizeof (*c) + size);
+  if (c == NULL) return NULL;
+  c->next = NULL;
+  c->used = 0;
+  c->size = size;
+  return c;
+}
+
+void *arena_alloc (arena_t *a, size_t size) {
+  size_t align = _Alignof (max_align_t);
+  size = (size + align - 1) & ~(align - 1);
+  arena_chunk_t *c = a->head;
+  if (c == NULL || c->used + size + align > c->size) {
+    size_t chunk_size
+      = size + align > ARENA_DEFAULT_CHUNK_SIZE ? size + align : ARENA_DEFAULT_CHUNK_SIZE;
+    arena_chunk_t *n = new_chunk (chunk_size);
+    if (n == NULL) return NULL;
+    n->next = c;
+    a->head = c = n;
+  }
+  c->used = (c->used + align - 1) & ~(align - 1);
+  void *mem = c->data + c->used;
+  c->used += size;
+  return mem;
+}
+
+char *arena_strdup (arena_t *a, const char *s) {
+  size_t len = strlen (s) + 1;
+  char *res = arena_alloc (a, len);
+  if (res == NULL) return NULL;
+  memcpy (res, s, len);
+  return res;
+}
+
+void arena_release (arena_t *a) {
+  arena_chunk_t *c = a->head;
+  while (c != NULL) {
+    arena_chunk_t *next = c->next;
+    free (c);
+    c = next;
+  }
+  a->head = NULL;
+}

--- a/examples/basic/arena.h
+++ b/examples/basic/arena.h
@@ -1,0 +1,22 @@
+#ifndef ARENA_H
+#define ARENA_H
+
+#include <stddef.h>
+
+typedef struct arena_chunk {
+  struct arena_chunk *next;
+  size_t used;
+  size_t size;
+  _Alignas (max_align_t) char data[];
+} arena_chunk_t;
+
+typedef struct {
+  arena_chunk_t *head;
+} arena_t;
+
+void arena_init (arena_t *a);
+void *arena_alloc (arena_t *a, size_t size);
+char *arena_strdup (arena_t *a, const char *s);
+void arena_release (arena_t *a);
+
+#endif /* ARENA_H */


### PR DESCRIPTION
## Summary
- Add a simple chunk-based arena allocator for fast linear allocation
- Allocate BASIC AST nodes and strings from a global arena and drop recursive free helpers
- Hook arena allocator into build for all BASIC compiler variants

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689af67179c0832686fca9a1ae2e9125