### PR TITLE
Add BASIC runtime arena reset and finish API

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -416,19 +416,19 @@ endif
 
 $(BUILD_DIR)/basic/basicc$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
-        $(SRC_DIR)/examples/basic/arena.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm $(EXEO)$@
 $(BUILD_DIR)/basic/basicc_ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
-        $(SRC_DIR)/examples/basic/arena.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE $^ -lm $(EXEO)$@
 
 
 $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/examples/basic/basicc.c $(SRC_DIR)/examples/basic/basic_runtime.c \
-        $(SRC_DIR)/examples/basic/arena.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/ryu/ld2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c $(SRC_DIR)/examples/basic/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/examples/basic -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -lm $(EXEO)$@
@@ -443,6 +443,7 @@ $(BUILD_DIR)/basic/kitty_test$(EXE): \
 $(BUILD_DIR)/basic/hcolor_test$(EXE): \
         $(SRC_DIR)/examples/basic/hcolor_test.c \
         $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c \
         $(SRC_DIR)/examples/basic/kitty/lodepng.c \
@@ -452,6 +453,7 @@ $(BUILD_DIR)/basic/hcolor_test$(EXE): \
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
         $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c \
         $(SRC_DIR)/examples/basic/kitty/lodepng.c \
@@ -459,6 +461,7 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
         $(SRC_DIR)/examples/basic/basic_runtime.c \
+        $(SRC_DIR)/examples/basic/basic_arena.c $(SRC_DIR)/examples/basic/arena.c \
         $(SRC_DIR)/examples/basic/ryu/d2s.c $(SRC_DIR)/examples/basic/ryu/f2s.c \
         $(SRC_DIR)/examples/basic/ryu/ld2s.c \
         $(SRC_DIR)/examples/basic/kitty/kitty.c \

--- a/examples/basic/basic_arena.c
+++ b/examples/basic/basic_arena.c
@@ -1,0 +1,14 @@
+#include "basic_arena.h"
+#include "arena.h"
+
+static arena_t basic_arena;
+
+void basic_arena_reset (void) {
+  for (arena_chunk_t *c = basic_arena.head; c != NULL; c = c->next) c->used = 0;
+}
+
+void basic_arena_finish (void) { arena_release (&basic_arena); }
+
+void *basic_arena_alloc (size_t size) { return arena_alloc (&basic_arena, size); }
+
+char *basic_arena_strdup (const char *s) { return arena_strdup (&basic_arena, s); }

--- a/examples/basic/basic_arena.h
+++ b/examples/basic/basic_arena.h
@@ -1,0 +1,11 @@
+#ifndef BASIC_ARENA_H
+#define BASIC_ARENA_H
+
+#include <stddef.h>
+
+void basic_arena_reset (void);
+void basic_arena_finish (void);
+void *basic_arena_alloc (size_t size);
+char *basic_arena_strdup (const char *s);
+
+#endif /* BASIC_ARENA_H */

--- a/examples/basic/basic_arena_test.c
+++ b/examples/basic/basic_arena_test.c
@@ -1,0 +1,14 @@
+#include "basic_arena.h"
+#include <stdio.h>
+#include <string.h>
+
+int main (void) {
+  char *s = basic_arena_strdup ("hello");
+  if (strcmp (s, "hello") != 0) return 1;
+  basic_arena_reset ();
+  char *t = basic_arena_strdup ("bye");
+  if (strcmp (t, "bye") != 0) return 1;
+  basic_arena_finish ();
+  printf ("basic_arena_test OK\n");
+  return 0;
+}

--- a/examples/basic/basic_arena_test.out
+++ b/examples/basic/basic_arena_test.out
@@ -1,0 +1,1 @@
+basic_arena_test OK

--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -395,6 +395,11 @@ char *basic_read_str (void) {
 
 void basic_restore (void) { basic_data_pos = 0; }
 
+void basic_clear (void) {
+  basic_restore ();
+  basic_arena_reset ();
+}
+
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str) {
   size_t n = (size_t) len;
   int str_p = is_str != 0.0;

--- a/examples/basic/basic_runtime.h
+++ b/examples/basic/basic_runtime.h
@@ -3,6 +3,7 @@
 #include "basic_num.h"
 #include "mir.h"
 #include "mir-gen.h"
+#include "basic_arena.h"
 
 basic_num_t basic_mir_ctx (void);
 basic_num_t basic_mir_mod (basic_num_t ctx, const char *name);
@@ -19,5 +20,6 @@ basic_num_t basic_mir_run (basic_num_t func, basic_num_t a1, basic_num_t a2, bas
 basic_num_t basic_mir_dump (basic_num_t func);
 
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str);
+void basic_clear (void);
 
 #endif /* BASIC_RUNTIME_H */

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -306,6 +306,7 @@ static void *resolve (const char *name) {
   if (!strcmp (name, "basic_sound")) return basic_sound;
   if (!strcmp (name, "basic_system")) return basic_system;
   if (!strcmp (name, "basic_system_out")) return basic_system_out;
+  if (!strcmp (name, "basic_clear")) return basic_clear;
 
   if (!strcmp (name, "basic_strdup")) return basic_strdup;
   if (!strcmp (name, "basic_free")) return basic_free;
@@ -346,24 +347,24 @@ static MIR_item_t rnd_proto, rnd_import, chr_proto, chr_import, string_proto, st
 /* Runtime call prototypes for statements */
 static MIR_item_t print_proto, print_import, prints_proto, prints_import, input_proto, input_import,
   input_str_proto, input_str_import, get_proto, get_import, put_proto, put_import, read_proto,
-  read_import, read_str_proto, read_str_import, restore_proto, restore_import, screen_proto,
-  screen_import, cls_proto, cls_import, color_proto, color_import, keyoff_proto, keyoff_import,
-  locate_proto, locate_import, htab_proto, htab_import, home_proto, poke_proto, poke_import,
-  home_import, vtab_proto, vtab_import, text_proto, text_import, inverse_proto, inverse_import,
-  normal_proto, normal_import, hgr2_proto, hgr2_import, hcolor_proto, hcolor_import, hplot_proto,
-  hplot_import, hplotto_proto, hplotto_import, hplottocur_proto, hplottocur_import, move_proto,
-  move_import, draw_proto, draw_import, line_proto, line_import, circle_proto, circle_import,
-  rect_proto, rect_import, mode_proto, mode_import, fill_proto, fill_import, calloc_proto,
-  calloc_import, memset_proto, memset_import, clear_array_proto, clear_array_import, strcmp_proto,
-  strcmp_import, open_proto, open_import, close_proto, close_import, printh_proto, printh_import,
-  prinths_proto, prinths_import, input_hash_proto, input_hash_import, input_hash_str_proto,
-  input_hash_str_import, get_hash_proto, get_hash_import, put_hash_proto, put_hash_import,
-  randomize_proto, randomize_import, stop_proto, stop_import, on_error_proto, on_error_import,
-  set_line_proto, set_line_import, get_line_proto, get_line_import, line_track_proto,
-  line_track_import, profile_line_proto, profile_line_import, profile_func_enter_proto,
-  profile_func_enter_import, profile_func_exit_proto, profile_func_exit_import, beep_proto,
-  beep_import, sound_proto, sound_import, system_proto, system_import, system_out_proto,
-  system_out_import, free_proto, free_import;
+  read_import, read_str_proto, read_str_import, restore_proto, restore_import, clear_proto,
+  clear_import, screen_proto, screen_import, cls_proto, cls_import, color_proto, color_import,
+  keyoff_proto, keyoff_import, locate_proto, locate_import, htab_proto, htab_import, home_proto,
+  poke_proto, poke_import, home_import, vtab_proto, vtab_import, text_proto, text_import,
+  inverse_proto, inverse_import, normal_proto, normal_import, hgr2_proto, hgr2_import, hcolor_proto,
+  hcolor_import, hplot_proto, hplot_import, hplotto_proto, hplotto_import, hplottocur_proto,
+  hplottocur_import, move_proto, move_import, draw_proto, draw_import, line_proto, line_import,
+  circle_proto, circle_import, rect_proto, rect_import, mode_proto, mode_import, fill_proto,
+  fill_import, calloc_proto, calloc_import, memset_proto, memset_import, clear_array_proto,
+  clear_array_import, strcmp_proto, strcmp_import, open_proto, open_import, close_proto,
+  close_import, printh_proto, printh_import, prinths_proto, prinths_import, input_hash_proto,
+  input_hash_import, input_hash_str_proto, input_hash_str_import, get_hash_proto, get_hash_import,
+  put_hash_proto, put_hash_import, randomize_proto, randomize_import, stop_proto, stop_import,
+  on_error_proto, on_error_import, set_line_proto, set_line_import, get_line_proto, get_line_import,
+  line_track_proto, line_track_import, profile_line_proto, profile_line_import,
+  profile_func_enter_proto, profile_func_enter_import, profile_func_exit_proto,
+  profile_func_exit_import, beep_proto, beep_import, sound_proto, sound_import, system_proto,
+  system_import, system_out_proto, system_out_import, free_proto, free_import;
 
 /* AST for expressions */
 typedef enum { N_NUM, N_VAR, N_BIN, N_NEG, N_NOT, N_STR, N_CALL } NodeKind;
@@ -3866,8 +3867,8 @@ static void gen_stmt (Stmt *s) {
       }
     }
     MIR_append_insn (g_ctx, g_func,
-                     MIR_new_call_insn (g_ctx, 2, MIR_new_ref_op (g_ctx, restore_proto),
-                                        MIR_new_ref_op (g_ctx, restore_import)));
+                     MIR_new_call_insn (g_ctx, 2, MIR_new_ref_op (g_ctx, clear_proto),
+                                        MIR_new_ref_op (g_ctx, clear_import)));
     break;
   }
   case ST_INVERSE: {
@@ -4681,6 +4682,7 @@ static void gen_stmt (Stmt *s) {
 static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p, int code_p,
                          int reduce_libs, int profile_p, int track_lines, const char *out_name,
                          const char *src_name) {
+  basic_arena_finish ();
   MIR_context_t ctx = MIR_init ();
   MIR_module_t module = MIR_new_module (ctx, "BASIC");
   print_proto = MIR_new_proto (ctx, "basic_print_p", 0, NULL, 1, MIR_T_D, "x");
@@ -4915,6 +4917,8 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   clear_array_import = MIR_new_import (ctx, "basic_clear_array");
   restore_proto = MIR_new_proto (ctx, "basic_restore_p", 0, NULL, 0);
   restore_import = MIR_new_import (ctx, "basic_restore");
+  clear_proto = MIR_new_proto (ctx, "basic_clear_p", 0, NULL, 0);
+  clear_import = MIR_new_import (ctx, "basic_clear");
   g_ctx = ctx;
   for (size_t i = 0; i < func_defs.len; i++) {
     FuncDef *fd = &func_defs.data[i];
@@ -5367,6 +5371,7 @@ static void repl (void) {
         func_vec_clear (&func_defs);
         data_vals_clear ();
         line_vec_destroy (&prog);
+        basic_arena_finish ();
         load_program (&prog, fname);
       }
       free (fname);
@@ -5377,6 +5382,7 @@ static void repl (void) {
       func_vec_clear (&func_defs);
       data_vals_clear ();
       line_vec_destroy (&prog);
+      basic_arena_finish ();
       arena_release (&ast_arena);
       continue;
     case REPL_TOK_QUIT:
@@ -5385,6 +5391,7 @@ static void repl (void) {
     }
     if (exit_repl) break;
   }
+  basic_arena_finish ();
   arena_release (&ast_arena);
 }
 
@@ -5421,10 +5428,12 @@ int main (int argc, char **argv) {
   }
   LineVec prog = {0};
   if (!load_program (&prog, fname)) {
+    basic_arena_finish ();
     arena_release (&ast_arena);
     return 1;
   }
   gen_program (&prog, jit, asm_p, obj_p, bin_p, 0, reduce_libs, 0, line_tracking, out_name, fname);
+  basic_arena_finish ();
   arena_release (&ast_arena);
   return 0;
 }

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -121,6 +121,23 @@ PY
         diff "$ROOT/examples/basic/basic_pool_test.out" "$ROOT/basic/basic_pool_test.out"
         echo "basic_pool_test OK"
 
+        echo "Building basic_arena_test"
+        cc -Wall -Wextra -I"$ROOT/examples/basic" \
+                "$ROOT/examples/basic/arena.c" \
+                "$ROOT/examples/basic/basic_arena.c" \
+                "$ROOT/examples/basic/basic_arena_test.c" \
+                -o "$ROOT/basic/basic_arena_test"
+        echo "Running basic_arena_test"
+        "$ROOT/basic/basic_arena_test" > "$ROOT/basic/basic_arena_test.out" 2> "$ROOT/basic/basic_arena_test.err"
+        if [ -s "$ROOT/basic/basic_arena_test.err" ]; then
+                echo "Unexpected stderr for basic_arena_test"
+                cat "$ROOT/basic/basic_arena_test.err"
+                exit 1
+        fi
+        rm -f "$ROOT/basic/basic_arena_test.err"
+        diff "$ROOT/examples/basic/basic_arena_test.out" "$ROOT/basic/basic_arena_test.out"
+        echo "basic_arena_test OK"
+
         echo "Building extlib"
         if [[ "$BASICC" == *-ld ]]; then
                 cc -shared -fPIC -Wall -Wextra -DBASIC_USE_LONG_DOUBLE -I"$ROOT/examples/basic" \


### PR DESCRIPTION
## Summary
- introduce basic_arena helpers for temporary allocations and reset/finish operations
- hook CLEAR to runtime basic_clear which resets arena
- release arena memory when loading or exiting programs and add regression test

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b00cc09f083268e38824fbbb872a2