### PR TITLE
Use pool allocator in BASIC runtime

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -17,6 +17,8 @@
 #include <sys/time.h>
 #include "kitty/kitty.h"
 #include "basic_runtime.h"
+#include "basic_pool.h"
+#include "basic_pool.c"
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_T_D MIR_T_LD
 #define MIR_new_double_op MIR_new_ldouble_op
@@ -201,10 +203,15 @@ basic_num_t basic_get_line (void) {
 }
 
 /* Release a string allocated by BASIC runtime helpers. */
-void basic_free (char *s) { free (s); }
+void basic_free (char *s) { (void) s; }
 
-/* Duplicate a C string using malloc; result must be freed with basic_free. */
-char *basic_strdup (const char *s) { return strdup (s); }
+/* Duplicate a C string using the BASIC memory pool. */
+char *basic_strdup (const char *s) {
+  size_t len = strlen (s);
+  char *res = basic_alloc_string (len);
+  if (res != NULL) memcpy (res, s, len);
+  return res;
+}
 
 basic_num_t basic_input (void) {
   basic_num_t x = 0.0;
@@ -230,19 +237,18 @@ basic_num_t basic_pos (void) { return (basic_num_t) basic_pos_val; }
    Caller must free the returned buffer with basic_free. */
 char *basic_input_str (void) {
   char buf[256];
-  if (fgets (buf, sizeof (buf), stdin) == NULL) return strdup ("");
+  if (fgets (buf, sizeof (buf), stdin) == NULL) return basic_strdup ("");
   size_t len = strlen (buf);
   if (len > 0 && buf[len - 1] == '\n') buf[len - 1] = '\0';
-  return strdup (buf);
+  return basic_strdup (buf);
 }
 /* Allocate a one-character string from stdin.
    Caller must free the returned buffer with basic_free. */
 char *basic_get (void) {
   int c = getchar ();
   if (c == EOF) c = 0;
-  char *s = malloc (2);
-  s[0] = (char) c;
-  s[1] = '\0';
+  char *s = basic_alloc_string (1);
+  if (s != NULL) s[0] = (char) c;
   return s;
 }
 
@@ -256,14 +262,12 @@ char *basic_inkey (void) {
   if (select (1, &fds, NULL, NULL, &tv) > 0) {
     int c = getchar ();
     if (c == EOF) c = 0;
-    char *s = malloc (2);
-    s[0] = (char) c;
-    s[1] = '\0';
+    char *s = basic_alloc_string (1);
+    if (s != NULL) s[0] = (char) c;
     return s;
   }
-  char *s = malloc (2);
-  s[0] = 0;
-  s[1] = '\0';
+  char *s = basic_alloc_string (1);
+  if (s != NULL) s[0] = 0;
   return s;
 }
 
@@ -331,12 +335,12 @@ basic_num_t basic_input_hash (basic_num_t n) {
    Caller must free the result with basic_free. */
 char *basic_input_hash_str (basic_num_t n) {
   int idx = (int) n;
-  if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return strdup ("");
+  if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return basic_strdup ("");
   char buf[256];
-  if (fgets (buf, sizeof (buf), basic_files[idx]) == NULL) return strdup ("");
+  if (fgets (buf, sizeof (buf), basic_files[idx]) == NULL) return basic_strdup ("");
   size_t len = strlen (buf);
   if (len > 0 && buf[len - 1] == '\n') buf[len - 1] = '\0';
-  return strdup (buf);
+  return basic_strdup (buf);
 }
 
 /* Read a single character from an open file and return it as a
@@ -344,16 +348,14 @@ char *basic_input_hash_str (basic_num_t n) {
 char *basic_get_hash (basic_num_t n) {
   int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
-    char *s = malloc (2);
-    s[0] = 0;
-    s[1] = '\0';
+    char *s = basic_alloc_string (1);
+    if (s != NULL) s[0] = 0;
     return s;
   }
   int c = fgetc (basic_files[idx]);
   if (c == EOF) c = 0;
-  char *s = malloc (2);
-  s[0] = (char) c;
-  s[1] = '\0';
+  char *s = basic_alloc_string (1);
+  if (s != NULL) s[0] = (char) c;
   return s;
 }
 
@@ -402,7 +404,7 @@ void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str) {
   if (str_p) {
     char **arr = (char **) base;
     for (size_t i = 0; i < n; i++) {
-      free (arr[i]);
+      basic_free (arr[i]);
       arr[i] = NULL;
     }
     memset (arr, 0, n * sizeof (char *));
@@ -480,9 +482,8 @@ basic_num_t basic_exp (basic_num_t x) { return BASIC_EXP (x); }
 
 /* Allocate a one-character string. Caller must free with basic_free. */
 char *basic_chr (basic_num_t n) {
-  char *s = malloc (2);
-  s[0] = (char) ((int) n);
-  s[1] = '\0';
+  char *s = basic_alloc_string (1);
+  if (s != NULL) s[0] = (char) ((int) n);
   return s;
 }
 
@@ -491,9 +492,8 @@ char *basic_chr (basic_num_t n) {
 char *basic_string (basic_num_t n, const char *s) {
   int len = (int) n;
   char ch = s != NULL && s[0] != '\0' ? s[0] : '\0';
-  char *res = malloc ((size_t) len + 1);
+  char *res = basic_alloc_string ((size_t) len);
   for (int i = 0; i < len; i++) res[i] = ch;
-  res[len] = '\0';
   return res;
 }
 
@@ -502,9 +502,9 @@ char *basic_string (basic_num_t n, const char *s) {
 char *basic_concat (const char *a, const char *b) {
   size_t la = strlen (a);
   size_t lb = strlen (b);
-  char *res = malloc (la + lb + 1);
+  char *res = basic_alloc_string (la + lb);
   memcpy (res, a, la);
-  memcpy (res + la, b, lb + 1);
+  memcpy (res + la, b, lb);
   return res;
 }
 
@@ -514,9 +514,8 @@ char *basic_left (const char *s, basic_num_t n) {
   size_t len = strlen (s);
   size_t cnt = (size_t) n;
   if (cnt > len) cnt = len;
-  char *res = malloc (cnt + 1);
+  char *res = basic_alloc_string (cnt);
   memcpy (res, s, cnt);
-  res[cnt] = '\0';
   return res;
 }
 
@@ -526,7 +525,7 @@ char *basic_right (const char *s, basic_num_t n) {
   size_t len = strlen (s);
   size_t cnt = (size_t) n;
   if (cnt > len) cnt = len;
-  return strdup (s + len - cnt);
+  return basic_strdup (s + len - cnt);
 }
 
 /* Return a substring of S starting at START_D with length LEN_D.
@@ -536,12 +535,11 @@ char *basic_mid (const char *s, basic_num_t start_d, basic_num_t len_d) {
   size_t start = (size_t) start_d;
   if (start < 1) start = 1;
   start--;
-  if (start >= len) return strdup ("");
+  if (start >= len) return basic_strdup ("");
   size_t cnt = len_d < 0 ? len - start : (size_t) len_d;
   if (start + cnt > len) cnt = len - start;
-  char *res = malloc (cnt + 1);
+  char *res = basic_alloc_string (cnt);
   memcpy (res, s + start, cnt);
-  res[cnt] = '\0';
   return res;
 }
 
@@ -560,7 +558,7 @@ basic_num_t basic_val (const char *s) { return BASIC_STRTOF (s, NULL); }
 char *basic_str (basic_num_t n) {
   char buf[128];
   basic_num_to_chars (n, buf, sizeof (buf));
-  return strdup (buf);
+  return basic_strdup (buf);
 }
 
 basic_num_t basic_asc (const char *s) {
@@ -584,7 +582,7 @@ char *basic_time_str (void) {
   struct tm *tm_info = localtime (&t);
   char buf[9];
   strftime (buf, sizeof (buf), "%H:%M:%S", tm_info);
-  return strdup (buf);
+  return basic_strdup (buf);
 }
 
 basic_num_t basic_date (void) {
@@ -597,14 +595,14 @@ char *basic_date_str (void) {
   struct tm *tm_info = localtime (&t);
   char buf[11];
   strftime (buf, sizeof (buf), "%Y-%m-%d", tm_info);
-  return strdup (buf);
+  return basic_strdup (buf);
 }
 
 /* Read N characters from stdin and return them as a newly allocated string.
    Caller must free the result with basic_free. */
 char *basic_input_chr (basic_num_t n) {
   int len = (int) n;
-  char *res = malloc ((size_t) len + 1);
+  char *res = basic_alloc_string ((size_t) len);
   int i = 0;
   for (; i < len; i++) {
     int c = getchar ();
@@ -850,7 +848,9 @@ double basic_system (const char *cmd) {
   return -1.0;
 }
 
-char *basic_system_out (void) { return system_output ? strdup (system_output) : strdup (""); }
+char *basic_system_out (void) {
+  return system_output ? basic_strdup (system_output) : basic_strdup ("");
+}
 
 void basic_stop (void) {
   fflush (stdout);

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -3,6 +3,7 @@
 #include "basic_runtime.h"
 #include "basic_num.h"
 #include "arena.h"
+#include "basic_pool.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_T_D MIR_T_LD
@@ -309,6 +310,7 @@ static void *resolve (const char *name) {
 
   if (!strcmp (name, "basic_strdup")) return basic_strdup;
   if (!strcmp (name, "basic_free")) return basic_free;
+  if (!strcmp (name, "basic_pool_reset")) return basic_pool_reset;
 
   if (!strcmp (name, "calloc")) return calloc;
   if (!strcmp (name, "memset")) return memset;
@@ -346,24 +348,24 @@ static MIR_item_t rnd_proto, rnd_import, chr_proto, chr_import, string_proto, st
 /* Runtime call prototypes for statements */
 static MIR_item_t print_proto, print_import, prints_proto, prints_import, input_proto, input_import,
   input_str_proto, input_str_import, get_proto, get_import, put_proto, put_import, read_proto,
-  read_import, read_str_proto, read_str_import, restore_proto, restore_import, screen_proto,
-  screen_import, cls_proto, cls_import, color_proto, color_import, keyoff_proto, keyoff_import,
-  locate_proto, locate_import, htab_proto, htab_import, home_proto, poke_proto, poke_import,
-  home_import, vtab_proto, vtab_import, text_proto, text_import, inverse_proto, inverse_import,
-  normal_proto, normal_import, hgr2_proto, hgr2_import, hcolor_proto, hcolor_import, hplot_proto,
-  hplot_import, hplotto_proto, hplotto_import, hplottocur_proto, hplottocur_import, move_proto,
-  move_import, draw_proto, draw_import, line_proto, line_import, circle_proto, circle_import,
-  rect_proto, rect_import, mode_proto, mode_import, fill_proto, fill_import, calloc_proto,
-  calloc_import, memset_proto, memset_import, clear_array_proto, clear_array_import, strcmp_proto,
-  strcmp_import, open_proto, open_import, close_proto, close_import, printh_proto, printh_import,
-  prinths_proto, prinths_import, input_hash_proto, input_hash_import, input_hash_str_proto,
-  input_hash_str_import, get_hash_proto, get_hash_import, put_hash_proto, put_hash_import,
-  randomize_proto, randomize_import, stop_proto, stop_import, on_error_proto, on_error_import,
-  set_line_proto, set_line_import, get_line_proto, get_line_import, line_track_proto,
-  line_track_import, profile_line_proto, profile_line_import, profile_func_enter_proto,
-  profile_func_enter_import, profile_func_exit_proto, profile_func_exit_import, beep_proto,
-  beep_import, sound_proto, sound_import, system_proto, system_import, system_out_proto,
-  system_out_import, free_proto, free_import;
+  read_import, read_str_proto, read_str_import, restore_proto, restore_import, pool_reset_proto,
+  pool_reset_import, screen_proto, screen_import, cls_proto, cls_import, color_proto, color_import,
+  keyoff_proto, keyoff_import, locate_proto, locate_import, htab_proto, htab_import, home_proto,
+  poke_proto, poke_import, home_import, vtab_proto, vtab_import, text_proto, text_import,
+  inverse_proto, inverse_import, normal_proto, normal_import, hgr2_proto, hgr2_import, hcolor_proto,
+  hcolor_import, hplot_proto, hplot_import, hplotto_proto, hplotto_import, hplottocur_proto,
+  hplottocur_import, move_proto, move_import, draw_proto, draw_import, line_proto, line_import,
+  circle_proto, circle_import, rect_proto, rect_import, mode_proto, mode_import, fill_proto,
+  fill_import, calloc_proto, calloc_import, memset_proto, memset_import, clear_array_proto,
+  clear_array_import, strcmp_proto, strcmp_import, open_proto, open_import, close_proto,
+  close_import, printh_proto, printh_import, prinths_proto, prinths_import, input_hash_proto,
+  input_hash_import, input_hash_str_proto, input_hash_str_import, get_hash_proto, get_hash_import,
+  put_hash_proto, put_hash_import, randomize_proto, randomize_import, stop_proto, stop_import,
+  on_error_proto, on_error_import, set_line_proto, set_line_import, get_line_proto, get_line_import,
+  line_track_proto, line_track_import, profile_line_proto, profile_line_import,
+  profile_func_enter_proto, profile_func_enter_import, profile_func_exit_proto,
+  profile_func_exit_import, beep_proto, beep_import, sound_proto, sound_import, system_proto,
+  system_import, system_out_proto, system_out_import, free_proto, free_import;
 
 /* AST for expressions */
 typedef enum { N_NUM, N_VAR, N_BIN, N_NEG, N_NOT, N_STR, N_CALL } NodeKind;
@@ -3853,10 +3855,6 @@ static void gen_stmt (Stmt *s) {
                                             MIR_new_double_op (g_ctx, (basic_num_t) v->is_str)));
       } else if (v->is_str) {
         MIR_append_insn (g_ctx, g_func,
-                         MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, free_proto),
-                                            MIR_new_ref_op (g_ctx, free_import),
-                                            MIR_new_reg_op (g_ctx, v->reg)));
-        MIR_append_insn (g_ctx, g_func,
                          MIR_new_insn (g_ctx, MIR_MOV, MIR_new_reg_op (g_ctx, v->reg),
                                        MIR_new_int_op (g_ctx, 0)));
       } else {
@@ -3868,6 +3866,9 @@ static void gen_stmt (Stmt *s) {
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 2, MIR_new_ref_op (g_ctx, restore_proto),
                                         MIR_new_ref_op (g_ctx, restore_import)));
+    MIR_append_insn (g_ctx, g_func,
+                     MIR_new_call_insn (g_ctx, 2, MIR_new_ref_op (g_ctx, pool_reset_proto),
+                                        MIR_new_ref_op (g_ctx, pool_reset_import)));
     break;
   }
   case ST_INVERSE: {
@@ -4915,6 +4916,8 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   clear_array_import = MIR_new_import (ctx, "basic_clear_array");
   restore_proto = MIR_new_proto (ctx, "basic_restore_p", 0, NULL, 0);
   restore_import = MIR_new_import (ctx, "basic_restore");
+  pool_reset_proto = MIR_new_proto (ctx, "basic_pool_reset_p", 0, NULL, 0);
+  pool_reset_import = MIR_new_import (ctx, "basic_pool_reset");
   g_ctx = ctx;
   for (size_t i = 0; i < func_defs.len; i++) {
     FuncDef *fd = &func_defs.data[i];
@@ -5390,6 +5393,8 @@ static void repl (void) {
 
 int main (int argc, char **argv) {
   arena_init (&ast_arena);
+  basic_pool_init (0);
+  atexit (basic_pool_destroy);
   if (kitty_graphics_available ()) show_kitty_banner ();
   int jit = 0, asm_p = 0, obj_p = 0, bin_p = 0, reduce_libs = 0;
   const char *fname = NULL, *out_name = NULL;


### PR DESCRIPTION
## Summary
- initialize the BASIC memory pool at program start and clean it up automatically on exit
- reset the pool on CLEAR instead of freeing strings individually
- route BASIC runtime string helpers through the pool allocator

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b00e3f0d083268a3b83b2cebf0594