### PR TITLE
basic: allocate arrays in pool

### DIFF
--- a/examples/basic/basic_runtime.h
+++ b/examples/basic/basic_runtime.h
@@ -19,7 +19,7 @@ basic_num_t basic_mir_run (basic_num_t func, basic_num_t a1, basic_num_t a2, bas
                            basic_num_t a4);
 basic_num_t basic_mir_dump (basic_num_t func);
 
-void *basic_dim_alloc (void *base, size_t n, int is_str);
+void *basic_dim_alloc (void *base, basic_num_t len, basic_num_t is_str);
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str);
 
 #endif /* BASIC_RUNTIME_H */


### PR DESCRIPTION
## Summary
- add `basic_dim_alloc` to obtain zero-initialized arrays from the BASIC arena and reset them with `basic_clear_array`
- initialize the arena at startup and stop freeing arena-backed strings in the BASIC compiler
- route DIM code generation through the new helper using numeric lengths

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b080eba4c83268d0655f20d58b4b7