### PR TITLE
Free BASIC runtime handles on shutdown

### DIFF
--- a/examples/basic/basic_runtime.h
+++ b/examples/basic/basic_runtime.h
@@ -21,5 +21,6 @@ basic_num_t basic_mir_dump (basic_num_t func);
 
 void *basic_dim_alloc (void *base, basic_num_t len, basic_num_t is_str);
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str);
+void basic_runtime_fini (void);
 
 #endif /* BASIC_RUNTIME_H */


### PR DESCRIPTION
## Summary
- add `basic_runtime_fini` to release function handles and contexts
- invoke new finalizer from `basic_stop`
- export finalizer in `basic_runtime.h`

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b1f9c4ac483269cf2000c0835f78b