### PR TITLE
Allocate BASIC string literals in AST arena

### DIFF
--- a/examples/basic/arena.c
+++ b/examples/basic/arena.c
@@ -42,6 +42,14 @@ char *arena_strdup (arena_t *a, const char *s) {
   return res;
 }
 
+char *arena_strndup (arena_t *a, const char *s, size_t len) {
+  char *res = arena_alloc (a, len + 1);
+  if (res == NULL) return NULL;
+  memcpy (res, s, len);
+  res[len] = 0;
+  return res;
+}
+
 void arena_release (arena_t *a) {
   arena_chunk_t *c = a->head;
   while (c != NULL) {

--- a/examples/basic/arena.h
+++ b/examples/basic/arena.h
@@ -17,6 +17,7 @@ typedef struct {
 void arena_init (arena_t *a);
 void *arena_alloc (arena_t *a, size_t size);
 char *arena_strdup (arena_t *a, const char *s);
+char *arena_strndup (arena_t *a, const char *s, size_t len);
 void arena_release (arena_t *a);
 
 #endif /* ARENA_H */

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -1168,9 +1168,7 @@ static Token read_token (Parser *p) {
     const char *start = cur;
     while (*cur && *cur != '"') cur++;
     size_t len = cur - start;
-    char *s = malloc (len + 1);
-    memcpy (s, start, len);
-    s[len] = 0;
+    char *s = arena_strndup (&ast_arena, start, len);
     if (*cur == '"') cur++;
     t.type = TOK_STRING;
     t.str = s;


### PR DESCRIPTION
## Summary
- Duplicate tokenizer string literals with `arena_strndup` so they live in `ast_arena`.
- Expose new `arena_strndup` helper for length-bounded copies.

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b1fc13704832685312e354afb370a