### PR TITLE
Free previous storage on BASIC pool reinit

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -18,7 +18,7 @@ static size_t align_up (size_t n) {
 }
 
 void basic_pool_init (size_t size) {
-  pool = NULL;
+  if (pool != NULL) basic_pool_destroy ();
   if (size != 0) {
     pool = malloc (sizeof (PoolBlock));
     if (pool != NULL) {
@@ -32,6 +32,8 @@ void basic_pool_init (size_t size) {
         pool->next = NULL;
       }
     }
+  } else {
+    pool = NULL;
   }
 }
 

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -21,6 +21,13 @@ int main (void) {
   strcpy (s2, "bye");
   if (strcmp (s2, "bye") != 0) return 1;
 
+  basic_pool_init (0);
+  int *arr3 = basic_calloc (4, sizeof (int));
+  for (int i = 0; i < 4; ++i)
+    if (arr3[i] != 0) return 1;
+  if (basic_clear_array_pool (arr2, 4, sizeof (int))) return 1;
+  if (!basic_clear_array_pool (arr3, 4, sizeof (int))) return 1;
+
   basic_pool_destroy ();
   printf ("basic_pool_test OK\n");
   return 0;


### PR DESCRIPTION
## Summary
- free existing BASIC pool storage before reallocating
- extend basic_pool_test to verify pool reinitialization

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b1fd18d6483269d60964dee9ef32f