### PR TITLE
Use arena allocations for BASIC variable names

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -2690,7 +2690,7 @@ static MIR_reg_t get_var (VarVec *vars, MIR_context_t ctx, MIR_item_t func, cons
     if (tmp == NULL) return 0;
     vars->data = tmp;
   }
-  vars->data[vars->len].name = strdup (name);
+  vars->data[vars->len].name = arena_strdup (&ast_arena, name);
   vars->data[vars->len].is_str = is_str;
   vars->data[vars->len].is_array = 0;
   vars->data[vars->len].size = 0;
@@ -2720,7 +2720,7 @@ static MIR_reg_t get_array (VarVec *vars, MIR_context_t ctx, MIR_item_t func, co
     if (tmp == NULL) return 0;
     vars->data = tmp;
   }
-  vars->data[vars->len].name = strdup (name);
+  vars->data[vars->len].name = arena_strdup (&ast_arena, name);
   vars->data[vars->len].is_str = is_str;
   vars->data[vars->len].is_array = 1;
   vars->data[vars->len].size = size1 * (size2 ? size2 : 1);


### PR DESCRIPTION
## Summary
- allocate variable names in BASIC compiler using `arena_strdup` for cleaner lifetime management

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b1fc7999883269cc118ae1c3f22c8