### PR TITLE
basic: note pool allocator in basic_free

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -207,7 +207,8 @@ basic_num_t basic_get_line (void) {
 
 /* Release a string allocated by BASIC runtime helpers. */
 void basic_free (char *s) {
-  /* Memory is managed by an arena; individual frees are unnecessary. */
+  /* Memory is managed by a pool allocator; individual frees are unnecessary due to pooled
+   * allocation. */
   (void) s;
 }
 


### PR DESCRIPTION
## Summary
- clarify that `basic_free` uses pool allocation and doesn't require individual frees

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b1f9bf64883268a1f781bda63ccc7