### PR TITLE
Fix invalid free in BASIC DATA cleanup

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -435,7 +435,7 @@ static void data_vec_push (DataVec *v, BasicData d) {
 }
 
 static void data_vals_clear (void) {
-  for (size_t i = 0; i < data_vals.len; i++) free (data_vals.data[i].str);
+  for (size_t i = 0; i < data_vals.len; i++) basic_free (data_vals.data[i].str);
   free (data_vals.data);
   data_vals.data = NULL;
   data_vals.len = data_vals.cap = 0;


### PR DESCRIPTION
## Summary
- avoid freeing arena-managed DATA strings with `free`
- ensures BASIC tests like baseconv run without aborting

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b299ca3ac8326b00b69101e15d586