### PR TITLE
Add CHAIN statement to BASIC interpreter

### DIFF
--- a/dialect_syntax.md
+++ b/dialect_syntax.md
@@ -12,3 +12,4 @@ Supported BASIC instructions now include:
 - input with `INPUT` and single-character `GET`.
 - state reset via `CLEAR`.
 - multi-way branching with `ON...GOTO` and `ON...GOSUB`.
+- program chaining with `CHAIN <expr>` to replace the current program with another BASIC file (interpreter-only).

--- a/examples/basic/README
+++ b/examples/basic/README
@@ -7,6 +7,11 @@ speed up compiled programs but removes support for `RESUME` without an explicit
 line number and causes the `basic_get_line` helper to report an error if
 invoked.
 
+The interpreter also recognizes a `CHAIN <expr>` statement that clears the
+current program and loads another BASIC source file.  Because it depends on the
+interpreter runtime, programs containing `CHAIN` are rejected by compilation
+flags such as `-S`, `-c`, `-r`, `-b`, and `-j`.
+
 String formatting within `basicc` uses a `safe_snprintf` wrapper that aborts
 on truncation. Use this helper for any new text generation to avoid silent
 buffer overflows.

--- a/examples/basic/chain.bas
+++ b/examples/basic/chain.bas
@@ -1,0 +1,2 @@
+10 PRINT "START"
+20 CHAIN "hello.bas"

--- a/examples/basic/chain.out
+++ b/examples/basic/chain.out
@@ -1,0 +1,2 @@
+START
+HELLO

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -143,7 +143,7 @@ PY
 
 
 #for t in hello relop adder string strfuncs instr gosub on funcproc graphics normal vtab screen hplot_bounds readhplot restore data_read data_multi clear hgr2reset circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date random rnd_noarg hexoct def_fn; do
-for t in hello relop adder string strfuncs instr gosub on funcproc vtab restore data_read data_multi clear circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date random rnd_noarg hexoct def_fn; do
+for t in hello relop adder string strfuncs instr gosub on funcproc vtab restore data_read data_multi clear circle box sudoku array_oob_read array_oob_write dim_expr pi baseconv mir_demo datediff date random rnd_noarg hexoct def_fn chain; do
                 echo "Running $t"
                 run_test "$t"
                 echo "$t OK"


### PR DESCRIPTION
## Summary
- Add `CHAIN` statement and runtime to replace the running program with another BASIC source file
- Reject `CHAIN` when compiling and document interpreter-only usage
- Include regression test verifying chained execution

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b34363e6c832691db5edcfee4da74