### PR TITLE
Use max_align_t for BASIC pool alignment

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 
 typedef struct PoolBlock {
   char *data;
@@ -13,7 +14,7 @@ typedef struct PoolBlock {
 static PoolBlock *pool = NULL;
 
 static size_t align_up (size_t n) {
-  size_t align = sizeof (void *);
+  size_t align = _Alignof (max_align_t);
   return (n + align - 1) & ~(align - 1);
 }
 

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -1,6 +1,7 @@
 #include "basic_pool.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 int main (void) {
   basic_pool_init (0);
@@ -27,6 +28,14 @@ int main (void) {
     if (arr3[i] != 0) return 1;
   if (basic_clear_array_pool (arr2, 4, sizeof (int))) return 1;
   if (!basic_clear_array_pool (arr3, 4, sizeof (int))) return 1;
+
+#if defined(BASIC_USE_LONG_DOUBLE)
+  long double *ldarr = basic_calloc (4, sizeof (long double));
+  for (int i = 0; i < 4; ++i)
+    if (ldarr[i] != 0.0L) return 1;
+  if ((uintptr_t) ldarr % _Alignof (long double) != 0) return 1;
+  if (!basic_clear_array_pool (ldarr, 4, sizeof (long double))) return 1;
+#endif
 
   basic_pool_destroy ();
   printf ("basic_pool_test OK\n");

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -95,10 +95,17 @@ PY
         echo "hcolor_test OK"
 
         echo "Building basic_pool_test"
-        cc -Wall -Wextra -I"$ROOT/examples/basic" \
-                "$ROOT/examples/basic/basic_pool.c" \
-                "$ROOT/examples/basic/basic_pool_test.c" \
-                -o "$ROOT/basic/basic_pool_test"
+        if [[ "$BASICC" == *-ld ]]; then
+                cc -Wall -Wextra -DBASIC_USE_LONG_DOUBLE -I"$ROOT/examples/basic" \
+                        "$ROOT/examples/basic/basic_pool.c" \
+                        "$ROOT/examples/basic/basic_pool_test.c" \
+                        -o "$ROOT/basic/basic_pool_test"
+        else
+                cc -Wall -Wextra -I"$ROOT/examples/basic" \
+                        "$ROOT/examples/basic/basic_pool.c" \
+                        "$ROOT/examples/basic/basic_pool_test.c" \
+                        -o "$ROOT/basic/basic_pool_test"
+        fi
         echo "Running basic_pool_test"
         "$ROOT/basic/basic_pool_test" > "$ROOT/basic/basic_pool_test.out" 2> "$ROOT/basic/basic_pool_test.err"
         if [ -s "$ROOT/basic/basic_pool_test.err" ]; then


### PR DESCRIPTION
## Summary
- align BASIC memory pool with `_Alignof(max_align_t)`
- test long double pool allocations when enabled
- compile `basic_pool_test` with `BASIC_USE_LONG_DOUBLE` in tests

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b6c31d6108326a764b8447073d85a