### PR TITLE
basic: add pool free and reuse

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -10,7 +10,13 @@ typedef struct PoolBlock {
   struct PoolBlock *next;
 } PoolBlock;
 
+typedef struct FreeBlock {
+  size_t size;
+  struct FreeBlock *next;
+} FreeBlock;
+
 static PoolBlock *pool = NULL;
+static FreeBlock *free_list = NULL;
 
 static size_t align_up (size_t n) {
   size_t align = sizeof (void *);
@@ -19,6 +25,7 @@ static size_t align_up (size_t n) {
 
 void basic_pool_init (size_t size) {
   if (pool != NULL) basic_pool_destroy ();
+  free_list = NULL;
   if (size != 0) {
     pool = malloc (sizeof (PoolBlock));
     if (pool != NULL) {
@@ -46,12 +53,21 @@ static PoolBlock *curr_block (void) {
 
 void *basic_pool_alloc (size_t size) {
   size = align_up (size);
+  /* First, try to reuse a freed block. */
+  for (FreeBlock **pb = &free_list; *pb != NULL; pb = &(*pb)->next) {
+    if ((*pb)->size >= size) {
+      FreeBlock *res = *pb;
+      *pb = res->next;
+      return (char *) res + sizeof (FreeBlock);
+    }
+  }
   if (pool == NULL) basic_pool_init (1024);
   PoolBlock *b = curr_block ();
   if (b == NULL) return NULL;
-  if (b->pos + size > b->size) {
+  size_t total = sizeof (FreeBlock) + size;
+  if (b->pos + total > b->size) {
     size_t newsize = b->size ? b->size * 2 : 1024;
-    while (newsize < size) newsize *= 2;
+    while (newsize < total) newsize *= 2;
     PoolBlock *nb = malloc (sizeof (PoolBlock));
     if (nb == NULL) return NULL;
     nb->data = malloc (newsize);
@@ -65,13 +81,16 @@ void *basic_pool_alloc (size_t size) {
     b->next = nb;
     b = nb;
   }
-  void *res = b->data + b->pos;
-  b->pos += size;
-  return res;
+  FreeBlock *res = (FreeBlock *) (b->data + b->pos);
+  res->size = size;
+  res->next = NULL;
+  b->pos += total;
+  return (char *) res + sizeof (FreeBlock);
 }
 
 void basic_pool_reset (void) {
   for (PoolBlock *b = pool; b != NULL; b = b->next) b->pos = 0;
+  free_list = NULL;
 }
 
 void basic_pool_destroy (void) {
@@ -83,6 +102,7 @@ void basic_pool_destroy (void) {
     b = next;
   }
   pool = NULL;
+  free_list = NULL;
 }
 
 char *basic_alloc_string (size_t len) {
@@ -102,17 +122,9 @@ void *basic_calloc (size_t count, size_t elem_size) {
   return basic_alloc_array (count, elem_size, 1);
 }
 
-int basic_clear_array_pool (void *base, size_t count, size_t elem_size) {
-  if (base == NULL) return 1;
-  size_t n = align_up (count * elem_size);
-  for (PoolBlock *b = pool; b != NULL; b = b->next) {
-    char *start = b->data;
-    char *end = b->data + b->pos;
-    char *p = (char *) base;
-    if (p >= start && p + n == end) {
-      b->pos -= n;
-      return 1;
-    }
-  }
-  return 0;
+void basic_pool_free (void *p) {
+  if (p == NULL) return;
+  FreeBlock *b = (FreeBlock *) ((char *) p - sizeof (FreeBlock));
+  b->next = free_list;
+  free_list = b;
 }

--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -7,10 +7,10 @@ void basic_pool_init (size_t size);
 void *basic_pool_alloc (size_t size);
 void basic_pool_reset (void);
 void basic_pool_destroy (void);
+void basic_pool_free (void *p);
 
 char *basic_alloc_string (size_t len);
 void *basic_alloc_array (size_t count, size_t elem_size, int clear);
 void *basic_calloc (size_t count, size_t elem_size);
-int basic_clear_array_pool (void *base, size_t count, size_t elem_size);
 
 #endif /* BASIC_POOL_H */

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -5,28 +5,21 @@
 int main (void) {
   basic_pool_init (0);
 
-  char *s = basic_alloc_string (5);
-  strcpy (s, "hello");
-  if (strcmp (s, "hello") != 0) return 1;
+  char *s1 = basic_alloc_string (5);
+  strcpy (s1, "hello");
+  basic_pool_free (s1);
+  char *s2 = basic_alloc_string (5);
+  if (s1 != s2) return 1;
+  strcpy (s2, "world");
+  if (strcmp (s2, "world") != 0) return 1;
 
   int *arr1 = basic_calloc (4, sizeof (int));
+  arr1[0] = 42;
+  basic_pool_free (arr1);
   int *arr2 = basic_calloc (4, sizeof (int));
+  if (arr2 != arr1) return 1;
   for (int i = 0; i < 4; ++i)
-    if (arr1[i] != 0 || arr2[i] != 0) return 1;
-  if (basic_clear_array_pool (arr1, 4, sizeof (int))) return 1;
-  if (!basic_clear_array_pool (arr2, 4, sizeof (int))) return 1;
-
-  basic_pool_reset ();
-  char *s2 = basic_alloc_string (3);
-  strcpy (s2, "bye");
-  if (strcmp (s2, "bye") != 0) return 1;
-
-  basic_pool_init (0);
-  int *arr3 = basic_calloc (4, sizeof (int));
-  for (int i = 0; i < 4; ++i)
-    if (arr3[i] != 0) return 1;
-  if (basic_clear_array_pool (arr2, 4, sizeof (int))) return 1;
-  if (!basic_clear_array_pool (arr3, 4, sizeof (int))) return 1;
+    if (arr2[i] != 0) return 1;
 
   basic_pool_destroy ();
   printf ("basic_pool_test OK\n");

--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -206,11 +206,7 @@ basic_num_t basic_get_line (void) {
 }
 
 /* Release a string allocated by BASIC runtime helpers. */
-void basic_free (char *s) {
-  /* Memory is managed by a pool allocator; individual frees are unnecessary due to pooled
-   * allocation. */
-  (void) s;
-}
+void basic_free (char *s) { basic_pool_free (s); }
 
 /* Duplicate a C string using the BASIC allocator. */
 char *basic_strdup (const char *s) {
@@ -431,13 +427,11 @@ void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str) {
   size_t n = (size_t) len;
   int str_p = is_str != 0.0;
   if (base == NULL || n == 0) return;
-  size_t elem_size = str_p ? sizeof (char *) : sizeof (basic_num_t);
-  if (basic_clear_array_pool (base, n, elem_size)) return;
   if (str_p) {
-    memset (base, 0, n * sizeof (char *));
-  } else {
-    memset (base, 0, n * sizeof (basic_num_t));
+    char **sp = (char **) base;
+    for (size_t i = 0; i < n; i++) basic_pool_free (sp[i]);
   }
+  basic_pool_free (base);
 }
 
 void basic_home (void) { printf ("\x1b[2J\x1b[H"); }


### PR DESCRIPTION
## Summary
- track allocation headers and free list in BASIC pool
- add `basic_pool_free` and integrate with runtime helpers
- exercise pool re-use in `basic_pool_test`

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c677400832695a646ff2b5430bd