### PR TITLE
Free profiling tables on runtime shutdown

### DIFF
--- a/examples/basic/basic_runtime.c
+++ b/examples/basic/basic_runtime.c
@@ -916,6 +916,17 @@ static Handle *handle_tab = NULL;
 static size_t handle_len = 0;
 
 void basic_runtime_fini (void) {
+  if (func_profiles != NULL) {
+    for (size_t i = 0; i < func_profiles_len; i++) free ((char *) func_profiles[i].name);
+  }
+  free (line_profiles);
+  free (func_profiles);
+  free (func_stack);
+  line_profiles = NULL;
+  func_profiles = NULL;
+  func_stack = NULL;
+  line_profiles_len = func_profiles_len = func_stack_len = 0;
+  last_profile_line = -1;
   for (size_t i = 0; i < handle_len; ++i) {
     if (handle_tab[i].kind == H_FUNC) {
       free (handle_tab[i].ptr);


### PR DESCRIPTION
## Summary
- Release BASIC profiling tables and names during runtime finalization to avoid leaks

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c4bc7488326a56046d8179373ef