### PR TITLE
basic: rely on runtime constructor for pool

### DIFF
--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+/* Call once before any pool allocations.  The BASIC runtime initializes
+   the pool during startup, so standalone tools must invoke this manually
+   with the desired initial size. */
 void basic_pool_init (size_t size);
 void *basic_pool_alloc (size_t size);
 void basic_pool_reset (void);

--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -5449,7 +5449,6 @@ static void repl (void) {
 
 int main (int argc, char **argv) {
   arena_init (&ast_arena);
-  basic_pool_init (0);
   if (kitty_graphics_available ()) show_kitty_banner ();
   int jit = 0, asm_p = 0, obj_p = 0, bin_p = 0, reduce_libs = 0;
   const char *fname = NULL, *out_name = NULL;

--- a/examples/basic/run-tests.sh
+++ b/examples/basic/run-tests.sh
@@ -22,6 +22,10 @@ run_tests() {
                 (cd "$ROOT" && make "basic/$(basename "$BASICC")")
         fi
 
+        echo "Running REPL smoke test"
+        printf '10 PRINT 1\nRUN\nQUIT\n' | "$BASICC" > /dev/null
+        echo "REPL smoke test OK"
+
         run_test() {
                 local name="$1"
                 local in_file="$ROOT/examples/basic/$name.in"


### PR DESCRIPTION
## Summary
- drop redundant basic_pool_init call in basicc and rely on runtime constructor
- document that basic_pool_init must run once before any allocation
- add REPL smoke test so run-tests exercises both REPL and non-REPL modes

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c3e5b208326beabdc546ebe0fca