### PR TITLE
Reset BASIC pool instead of reinitializing in main

### DIFF
--- a/examples/basic/basicc.c
+++ b/examples/basic/basicc.c
@@ -5449,7 +5449,7 @@ static void repl (void) {
 
 int main (int argc, char **argv) {
   arena_init (&ast_arena);
-  basic_pool_init (0);
+  basic_pool_reset ();
   if (kitty_graphics_available ()) show_kitty_banner ();
   int jit = 0, asm_p = 0, obj_p = 0, bin_p = 0, reduce_libs = 0;
   const char *fname = NULL, *out_name = NULL;


### PR DESCRIPTION
## Summary
- Reset the BASIC memory pool in `basicc`'s `main` so the constructor-allocated pool remains active.
- Keep explicit `basic_pool_destroy` calls to ensure cleanup on program exit.

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c846df08326b597c345b3cc3329