### PR TITLE
Add basic pool array clearing

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -123,6 +123,24 @@ void *basic_calloc (size_t count, size_t elem_size) {
   return basic_alloc_array (count, elem_size, 1);
 }
 
+int basic_clear_array_pool (void *base, size_t count, size_t elem_size) {
+  if (base == NULL) return 0;
+  size_t n = count * elem_size;
+  if (n == 0) return 1;
+  for (PoolBlock *b = pool; b != NULL; b = b->next) {
+    char *start = b->data;
+    size_t size = b->size;
+    char *end = start + size;
+    char *ptr = (char *) base;
+    if (ptr >= start && ptr < end) {
+      if ((size_t) (end - ptr) < n) return 0;
+      memset (base, 0, n);
+      return 1;
+    }
+  }
+  return 0;
+}
+
 void basic_pool_free (void *p) {
   if (p == NULL) return;
   FreeBlock *b = (FreeBlock *) ((char *) p - sizeof (FreeBlock));

--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -15,5 +15,6 @@ void basic_pool_free (void *p);
 char *basic_alloc_string (size_t len);
 void *basic_alloc_array (size_t count, size_t elem_size, int clear);
 void *basic_calloc (size_t count, size_t elem_size);
+int basic_clear_array_pool (void *base, size_t count, size_t elem_size);
 
 #endif /* BASIC_POOL_H */

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -23,11 +23,12 @@ int main (void) {
     if (arr2[i] != 0) return 1;
 
 #if defined(BASIC_USE_LONG_DOUBLE)
-  long double *ldarr = basic_calloc (4, sizeof (long double));
+  long double *ldarr = basic_alloc_array (4, sizeof (long double), 0);
+  for (int i = 0; i < 4; ++i) ldarr[i] = 1.0L;
+  if (!basic_clear_array_pool (ldarr, 4, sizeof (long double))) return 1;
   for (int i = 0; i < 4; ++i)
     if (ldarr[i] != 0.0L) return 1;
   if ((uintptr_t) ldarr % _Alignof (long double) != 0) return 1;
-  if (!basic_clear_array_pool (ldarr, 4, sizeof (long double))) return 1;
 #endif
 
   basic_pool_destroy ();


### PR DESCRIPTION
## Summary
- add basic_clear_array_pool to zero memory within pool
- expose pool clearing API to headers
- test long double array clearing with pool allocator

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689b749dace48326b888cda7b98e84e1