### PR TITLE
Add missing basic_clear_array_pool API

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -129,3 +129,9 @@ void basic_pool_free (void *p) {
   b->next = free_list;
   free_list = b;
 }
+
+int basic_clear_array_pool (void *base, size_t count, size_t elem_size) {
+  if (base == NULL) return 0;
+  memset (base, 0, count * elem_size);
+  return 1;
+}

--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -11,6 +11,7 @@ void *basic_pool_alloc (size_t size);
 void basic_pool_reset (void);
 void basic_pool_destroy (void);
 void basic_pool_free (void *p);
+int basic_clear_array_pool (void *base, size_t count, size_t elem_size);
 
 char *basic_alloc_string (size_t len);
 void *basic_alloc_array (size_t count, size_t elem_size, int clear);


### PR DESCRIPTION
## Summary
- implement `basic_clear_array_pool` to zero out a pooled array
- expose `basic_clear_array_pool` in the BASIC memory pool header

## Testing
- `make basic-test`
- `./basic/basic_pool_test`


------
https://chatgpt.com/codex/tasks/task_e_689b74b942c083269f593c5f3180ab19