### PR TITLE
Add pool array clearing helper

### DIFF
--- a/examples/basic/basic_pool.c
+++ b/examples/basic/basic_pool.c
@@ -132,6 +132,12 @@ void basic_pool_free (void *p) {
 
 int basic_clear_array_pool (void *base, size_t count, size_t elem_size) {
   if (base == NULL) return 0;
-  memset (base, 0, count * elem_size);
-  return 1;
+  size_t n = count * elem_size;
+  for (PoolBlock *b = pool; b != NULL; b = b->next) {
+    if ((char *) base >= b->data && (char *) base + n <= b->data + b->size) {
+      memset (base, 0, n);
+      return 1;
+    }
+  }
+  return 0;
 }

--- a/examples/basic/basic_pool.h
+++ b/examples/basic/basic_pool.h
@@ -11,11 +11,9 @@ void *basic_pool_alloc (size_t size);
 void basic_pool_reset (void);
 void basic_pool_destroy (void);
 void basic_pool_free (void *p);
-int basic_clear_array_pool (void *base, size_t count, size_t elem_size);
-
 char *basic_alloc_string (size_t len);
 void *basic_alloc_array (size_t count, size_t elem_size, int clear);
 void *basic_calloc (size_t count, size_t elem_size);
-int basic_clear_array_pool (void *base, size_t len, size_t elem_size);
+int basic_clear_array_pool (void *base, size_t count, size_t elem_size);
 
 #endif /* BASIC_POOL_H */

--- a/examples/basic/basic_pool_test.c
+++ b/examples/basic/basic_pool_test.c
@@ -32,6 +32,10 @@ int main (void) {
   if (ldarr2 != ldarr1) return 1;
   for (int i = 0; i < 4; ++i)
     if (ldarr2[i] != 0.0L) return 1;
+  for (int i = 0; i < 4; ++i) ldarr2[i] = (long double) (i + 1);
+  if (!basic_clear_array_pool (ldarr2, 4, sizeof (long double))) return 1;
+  for (int i = 0; i < 4; ++i)
+    if (ldarr2[i] != 0.0L) return 1;
 #endif
 
   basic_pool_destroy ();


### PR DESCRIPTION
## Summary
- add `basic_clear_array_pool` to wipe pool-managed memory and return success
- expose new clearing API in the BASIC pool header
- test clearing of long double arrays through the pool helper

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689b7a5dc1548326bb7a0da879422f2f