### PR TITLE
docs: explain optional LET

### DIFF
--- a/examples/basic/README
+++ b/examples/basic/README
@@ -1,6 +1,8 @@
 BASIC Compiler Notes
 ====================
 
+Assignments may begin with the optional `LET` keyword. `LET X=1` and `X=1` are equivalent forms.
+
 The `basicc` compiler accepts the `--no-line-tracking` flag to skip inserting
 `basic_set_line` calls during code generation.  Disabling line tracking can
 speed up compiled programs but removes support for `RESUME` without an explicit

--- a/examples/basic/TUTORIAL.md
+++ b/examples/basic/TUTORIAL.md
@@ -17,6 +17,13 @@ The dialect supports line‑numbered programs in the style of early microcompute
 80 END
 ```
 
+Assignments may optionally use the classic `LET` keyword, though it is not required:
+
+```basic
+LET X = 1  ' explicit LET
+X = 1      ' implicit LET
+```
+
 Key features include `PRINT`, `INPUT`, `IF`/`THEN`, `ELSE`, `FOR`/`NEXT`, `WHILE`/`WEND`, `GOTO`, `GOSUB`/`RETURN`, `DATA`/`READ`/`RESTORE`, and arrays declared with `DIM`.
 
 ## Functions and Optional Line Numbers


### PR DESCRIPTION
## Summary
- Document that BASIC assignments may include or omit the `LET` keyword
- Add simple `LET X=1` and `X=1` example

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689c36057d648326811b4da2c1bf2937