### PR TITLE
Add Minimal BASIC test harness

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -468,6 +468,8 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
 basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
 	$(SRC_DIR)/examples/basic/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/examples/basic/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
+	$(SRC_DIR)/examples/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
+	$(SRC_DIR)/examples/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 
 # ------------------ MIR interp tests --------------------------
 .PHONY: clean-mir-interp-tests

--- a/examples/basic/README
+++ b/examples/basic/README
@@ -12,6 +12,15 @@ invoked.
 The compiler also understands `--option-base N` to set the default `OPTION BASE`
 for programs that omit it.  Specify `0` or `1` for `N`.
 
+Automated Tests
+---------------
+Run `make basic-test` to build the compiler and execute sample programs along with
+selected cases from the NBS Minimal BASIC suite.  The latter can also be run
+directly via `examples/basic/test/run-mbasic-tests.sh <path-to-basicc>`, which
+invokes each test in both interpreted and JIT-compiled modes and looks for
+`*** TEST PASSED ***` in their output.  Test `P173.BAS` is currently marked as an
+expected failure until TAB error handling is improved.
+
 The interpreter also recognizes a `CHAIN <expr>` statement that clears the
 current program and loads another BASIC source file.  Because it depends on the
 interpreter runtime, programs containing `CHAIN` are rejected by compilation

--- a/examples/basic/test/run-mbasic-tests.sh
+++ b/examples/basic/test/run-mbasic-tests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run selected Minimal BASIC test programs with basicc.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BASICC="${1:-$ROOT/basic/basicc}"
+
+# Selected test cases from the NBS Minimal BASIC suite.
+CASES=(
+  P001.BAS
+  P049.BAS
+  P067.BAS
+  P173.BAS
+  P174.BAS
+)
+
+# Programs currently expected to fail.
+XFAIL=(P173.BAS)
+
+run_case() {
+  local mode="$1"; shift
+  local file="$1"; shift
+  local src="$ROOT/examples/basic/test/mbasic-nbs/$file"
+  local -a flags=()
+  [[ "$mode" == compiled ]] && flags+=(-j)
+  echo "Running $file ($mode)"
+  local out
+  out="$("$BASICC" "${flags[@]}" "$src" 2>&1 || true)"
+  local ok=0
+  case "$file" in
+    P067.BAS)
+      if echo "$out" | grep -q '\*\*\* EXCEPTION SHOULD OCCUR NOW \*\*\*' \
+         && ! echo "$out" | grep -q '\*\*\* TEST FAILS \*\*\*'; then
+        ok=1
+      fi
+      ;;
+    *)
+      if echo "$out" | grep -q '\*\*\* TEST PASSED'; then
+        ok=1
+      fi
+      ;;
+  esac
+  if [[ $ok -eq 1 ]]; then
+    echo "$file ($mode) OK"
+  else
+    if [[ " ${XFAIL[*]} " == *" $file "* ]]; then
+      echo "$file ($mode) expected failure"
+    else
+      echo "$file ($mode) FAILED"
+      return 1
+    fi
+  fi
+}
+
+run_mode() {
+  local mode="$1"
+  local status=0
+  for file in "${CASES[@]}"; do
+    if ! run_case "$mode" "$file"; then
+      status=1
+    fi
+  done
+  return $status
+}
+
+# Run both interpreted and JIT-compiled modes.
+run_mode interpreted
+run_mode compiled
+


### PR DESCRIPTION
## Summary
- run selected NBS Minimal BASIC programs in both interpreted and JIT modes
- integrate NBS tests into `make basic-test`
- document new automated test script

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689c3bb8f9cc83268f4b86b08e5f9de0