### PR TITLE
Add optional Decimal128 support for BASIC compiler

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -411,6 +411,7 @@ else ifeq ($(UNAME_S),Darwin)
 else
   BASIC_RUNTIME_LIB=libbasic_runtime.so
   BASIC_RUNTIME_LIB_LD=libbasic_runtime_ld.so
+  BASIC_RUNTIME_LIB_D128=libbasic_runtime_d128.so
   BASIC_RUNTIME_FLAGS=-shared
 endif
 
@@ -819,3 +820,16 @@ csmith-c2m-gcc:
 	$(SHELL) csmith-c2m-gcc.sh
 csmith-c2m:
 	$(SHELL) csmith-c2m.sh
+
+$(BUILD_DIR)/basic/basicc-d128$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
+        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -DBASIC_USE_DECIMAL128 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $^ -ldfp -lm $(EXEO)$@
+
+$(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_D128): \
+        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor $(CFLAGS) $(LDFLAGS) -DBASIC_USE_DECIMAL128 $(BASIC_RUNTIME_FLAGS) $^ -ldfp -lm $(EXEO)$@

--- a/basic/docs/README
+++ b/basic/docs/README
@@ -3,6 +3,10 @@ BASIC Compiler Notes
 
 Assignments may begin with the optional `LET` keyword. `LET X=1` and `X=1` are equivalent forms. `INC X` and `DEC X` provide shorthand for incrementing or decrementing a numeric variable.
 
+By default the compiler uses binary double precision numbers.  Building with
+`-DBASIC_USE_LONG_DOUBLE` enables `long double` math, while defining
+`BASIC_USE_DECIMAL128` selects `_Decimal128` support via libdfp.
+
 The `basicc` compiler accepts the `--no-line-tracking` flag to skip inserting
 `basic_set_line` calls during code generation.  Disabling line tracking can
 speed up compiled programs but removes support for `RESUME` without an explicit

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -45,6 +45,36 @@
 #define MIR_DBLE MIR_LDBLE
 #define MIR_DBGT MIR_LDBGT
 #define MIR_DBGE MIR_LDBGE
+#elif defined(BASIC_USE_DECIMAL128)
+#define MIR_T_D MIR_T_LD
+#define MIR_new_double_op MIR_new_ldouble_op
+#define MIR_D2I MIR_LD2I
+#define MIR_I2D MIR_I2LD
+#define MIR_DMOV MIR_LDMOV
+#define MIR_DNEG MIR_LDNEG
+#define MIR_DEQ MIR_LDEQ
+#define MIR_DNE MIR_LDNE
+#define MIR_DLT MIR_LDLT
+#define MIR_DLE MIR_LDLE
+#define MIR_DGT MIR_LDGT
+#define MIR_DGE MIR_LDGE
+#define MIR_DADD MIR_LDADD
+#define MIR_DSUB MIR_LDSUB
+#define MIR_DMUL MIR_LDMUL
+#define MIR_DDIV MIR_LDDIV
+#define MIR_DBEQ MIR_LDBEQ
+#define MIR_DBNE MIR_LDBNE
+#define MIR_DBLT MIR_LDBLT
+#define MIR_DBLE MIR_LDBLE
+#define MIR_DBGT MIR_LDBGT
+#define MIR_DBGE MIR_LDBGE
+#endif
+
+#if defined(BASIC_USE_DECIMAL128)
+basic_num_t decimal128_add (basic_num_t a, basic_num_t b) { return a + b; }
+basic_num_t decimal128_sub (basic_num_t a, basic_num_t b) { return a - b; }
+basic_num_t decimal128_mul (basic_num_t a, basic_num_t b) { return a * b; }
+basic_num_t decimal128_div (basic_num_t a, basic_num_t b) { return a / b; }
 #endif
 
 static int seeded = 0;

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -28,6 +28,29 @@
 #define MIR_DBLE MIR_LDBLE
 #define MIR_DBGT MIR_LDBGT
 #define MIR_DBGE MIR_LDBGE
+#elif defined(BASIC_USE_DECIMAL128)
+#define MIR_T_D MIR_T_LD
+#define MIR_new_double_op MIR_new_ldouble_op
+#define MIR_D2I MIR_LD2I
+#define MIR_I2D MIR_I2LD
+#define MIR_DMOV MIR_LDMOV
+#define MIR_DNEG MIR_LDNEG
+#define MIR_DEQ MIR_LDEQ
+#define MIR_DNE MIR_LDNE
+#define MIR_DLT MIR_LDLT
+#define MIR_DLE MIR_LDLE
+#define MIR_DGT MIR_LDGT
+#define MIR_DGE MIR_LDGE
+#define MIR_DADD MIR_LDADD
+#define MIR_DSUB MIR_LDSUB
+#define MIR_DMUL MIR_LDMUL
+#define MIR_DDIV MIR_LDDIV
+#define MIR_DBEQ MIR_LDBEQ
+#define MIR_DBNE MIR_LDBNE
+#define MIR_DBLT MIR_LDBLT
+#define MIR_DBLE MIR_LDBLE
+#define MIR_DBGT MIR_LDBGT
+#define MIR_DBGE MIR_LDBGE
 #endif
 
 #include <ctype.h>
@@ -191,6 +214,12 @@ extern char *basic_date_str (void);
 extern char *basic_input_chr (basic_num_t);
 extern basic_num_t basic_peek (basic_num_t);
 extern void basic_poke (basic_num_t, basic_num_t);
+#if defined(BASIC_USE_DECIMAL128)
+extern basic_num_t decimal128_add (basic_num_t, basic_num_t);
+extern basic_num_t decimal128_sub (basic_num_t, basic_num_t);
+extern basic_num_t decimal128_mul (basic_num_t, basic_num_t);
+extern basic_num_t decimal128_div (basic_num_t, basic_num_t);
+#endif
 
 extern void basic_open (basic_num_t, const char *);
 extern void basic_close (basic_num_t);


### PR DESCRIPTION
## Summary
- add BASIC_USE_DECIMAL128 path in compiler and runtime
- expose decimal128 helpers and document build flag
- wire decimal128 variant into build system

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689c5ffa77e0832684e8a1fcdd36b001