### PR TITLE
Implement fixed64 multiplication without __int128

### DIFF
--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -13,10 +13,14 @@ int main (void) {
   res = fixed64_sub (two, half);
   assert (res.hi == 1 && res.lo == (1ULL << 63));
 
-#if 0
   res = fixed64_mul (two, half);
   assert (res.hi == 1 && res.lo == 0);
 
+  fixed64_t neg_two = fixed64_neg (two);
+  res = fixed64_mul (neg_two, half);
+  assert (res.hi == -1 && res.lo == 0);
+
+#if 0
   res = fixed64_div (two, half);
   assert (res.hi == 4 && res.lo == 0);
 #endif


### PR DESCRIPTION
## Summary
- Implement 64-bit based multiplication for the fixed64 type, enabling fixed-point math without `__int128` or external libraries.
- Expand fixed64 unit tests to cover multiplication including negative operands.

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689c887d4f988326aac63760f5d6d02d