### PR TITLE
Add fixed64 BASIC compiler target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -403,14 +403,17 @@ clean-mir-utility-tests:
 ifeq ($(OS),Windows_NT)
   BASIC_RUNTIME_LIB=basic_runtime.dll
   BASIC_RUNTIME_LIB_LD=basic_runtime_ld.dll
+  BASIC_RUNTIME_LIB_FIX=basic_runtime_fix.dll
   BASIC_RUNTIME_FLAGS=-shared
 else ifeq ($(UNAME_S),Darwin)
   BASIC_RUNTIME_LIB=libbasic_runtime.dylib
   BASIC_RUNTIME_LIB_LD=libbasic_runtime_ld.dylib
+  BASIC_RUNTIME_LIB_FIX=libbasic_runtime_fix.dylib
   BASIC_RUNTIME_FLAGS=-dynamiclib
 else
   BASIC_RUNTIME_LIB=libbasic_runtime.so
   BASIC_RUNTIME_LIB_LD=libbasic_runtime_ld.so
+  BASIC_RUNTIME_LIB_FIX=libbasic_runtime_fix.so
   BASIC_RUNTIME_FLAGS=-shared
 endif
 
@@ -441,6 +444,11 @@ $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir
         $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
         $(SRC_DIR)/basic/src/vendor/ryu/ld2s.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
+
+$(BUILD_DIR)/basic/basicc-fix$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
+        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/kitty_test$(EXE): \
         $(SRC_DIR)/basic/test/kitty_test.c \
@@ -480,11 +488,18 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
         $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor $(CFLAGS) $(LDFLAGS) -DBASIC_USE_LONG_DOUBLE $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
+$(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
+        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) -DBASIC_USE_FIXED64 $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/basicc-fix$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX) $(BUILD_DIR)/mir-bin-run$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
+	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-fix$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
+	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-fix$(EXE)
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out
 	$(BUILD_DIR)/basic/fixed64_test$(EXE)


### PR DESCRIPTION
## Summary
- add `basicc-fix` executable and runtime library using fixed64
- hook new target into BASIC tests

## Testing
- `make basic-test` *(fails: incompatible types when building basicc-fix)*

------
https://chatgpt.com/codex/tasks/task_e_689c924899fc83268daac9877e9e4bea