### PR TITLE
basic: abort on stray tokens after statement

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -2862,9 +2862,12 @@ static int parse_line (Parser *p, char *line, Line *out) {
         break;
       }
     }
+    if (s.kind != ST_REM) {
+      t = peek_token (p);
+      if (t.type != TOK_EOF && t.type != TOK_COLON) return parse_error (p);
+    }
     stmt_vec_push (&out->stmts, s);
     if (s.kind == ST_REM) break;
-    t = peek_token (p);
     if (t.type == TOK_COLON) {
       do {
         next_token (p);

--- a/basic/tests/programs/input_multi.bas
+++ b/basic/tests/programs/input_multi.bas
@@ -1,0 +1,2 @@
+10 INPUT A,B
+20 END

--- a/basic/tests/run-tests.sh
+++ b/basic/tests/run-tests.sh
@@ -200,7 +200,7 @@ PY
         for src in "$ROOT/basic/tests/programs/"*.bas; do
                 name=$(basename "$src" .bas)
                case "$name" in
-                       base0_cli|base1_cli|extern|resume|dim_expr_error|line_number_float|print_expr_error|incdec)
+                       base0_cli|base1_cli|extern|resume|dim_expr_error|line_number_float|print_expr_error|input_multi|incdec)
                                continue
                                ;;
                        ahl_benchmark)
@@ -272,6 +272,14 @@ if ! grep -q "parse error at line 10" "$ROOT/basic/print_expr_error.err"; then
         exit 1
 fi
 echo "print expression error OK"
+
+echo "Running input multi (expect error)"
+if "$BASICC" "$ROOT/basic/tests/programs/input_multi.bas" >/dev/null 2> "$ROOT/basic/input_multi.err"; then
+echo "input multi should have failed"
+exit 1
+fi
+grep -q "parse error at line 10" "$ROOT/basic/input_multi.err"
+echo "input multi error OK"
 
         echo "Running repl LOAD"
         printf 'LOAD %s\nRUN\nQUIT\n' "$ROOT/basic/tests/programs/hello.bas" | "$BASICC" > "$ROOT/basic/repl-load.out"


### PR DESCRIPTION
## Summary
- validate token stream after each statement and abort line on leftovers
- test that multi-variable INPUT is rejected

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689c9382bfd083269aed30572527a4c9