### PR TITLE
Use buffered parsing for BASIC numeric input

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -473,6 +473,9 @@ $(BUILD_DIR)/basic/fixed64_test$(EXE): \
         $(SRC_DIR)/basic/test/fixed64_test.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
+$(BUILD_DIR)/basic/basic_num_scan_test$(EXE): \
+        $(SRC_DIR)/basic/test/basic_num_scan_test.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
+
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
         $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
         $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
@@ -493,13 +496,15 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) -DBASIC_USE_FIXED64 $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out
+	$(BUILD_DIR)/basic/fixed64_test$(EXE)
+	$(BUILD_DIR)/basic/basic_num_scan_test$(EXE)
 
 # ------------------ MIR interp tests --------------------------
 .PHONY: clean-mir-interp-tests

--- a/basic/include/basic_num.h
+++ b/basic/include/basic_num.h
@@ -129,9 +129,10 @@ static inline int basic_num_to_chars (basic_num_t x, char *buf, size_t size) {
   return fixed64_to_string (x, buf, size);
 }
 static inline int BASIC_NUM_SCAN (FILE *f, basic_num_t *out) {
-  char buf[128];
+  char buf[128], *end;
   if (fgets (buf, sizeof (buf), f) == NULL) return 0;
-  *out = fixed64_from_string (buf, NULL);
+  *out = fixed64_from_string (buf, &end);
+  if (end == buf) return 0;
   return 1;
 }
 static inline void BASIC_NUM_PRINT (FILE *f, basic_num_t x) {
@@ -268,7 +269,11 @@ static inline int basic_num_to_chars (basic_num_t x, char *buf, size_t size) {
 
 #if !defined(BASIC_USE_FIXED64)
 static inline int BASIC_NUM_SCAN (FILE *f, basic_num_t *out) {
-  return fscanf (f, BASIC_NUM_SCANF, out) == 1;
+  char buf[128], *end;
+  if (fgets (buf, sizeof (buf), f) == NULL) return 0;
+  *out = BASIC_STRTOF (buf, &end);
+  if (end == buf) return 0;
+  return 1;
 }
 static inline void BASIC_NUM_PRINT (FILE *f, basic_num_t x) { fprintf (f, BASIC_NUM_PRINTF, x); }
 #endif

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -267,9 +267,17 @@ static char *next_input_field (void) {
   }
 }
 
+static int basic_read_num (FILE *f, basic_num_t *out) {
+  char buf[128], *end;
+  if (fgets (buf, sizeof (buf), f) == NULL) return 0;
+  *out = BASIC_STRTOF (buf, &end);
+  if (end == buf) return 0;
+  return 1;
+}
+
 basic_num_t basic_input (void) {
   basic_num_t x = BASIC_ZERO;
-  if (!BASIC_NUM_SCAN (stdin, &x)) return BASIC_ZERO;
+  if (!basic_read_num (stdin, &x)) return BASIC_ZERO;
   return x;
 }
 
@@ -375,7 +383,7 @@ basic_num_t basic_input_hash (basic_num_t n) {
   int idx = BASIC_TO_INT (n);
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return BASIC_ZERO;
   basic_num_t x = BASIC_ZERO;
-  if (!BASIC_NUM_SCAN (basic_files[idx], &x)) return BASIC_ZERO;
+  if (!basic_read_num (basic_files[idx], &x)) return BASIC_ZERO;
   return x;
 }
 

--- a/basic/test/basic_num_scan_test.c
+++ b/basic/test/basic_num_scan_test.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "basic_num.h"
+
+int main (void) {
+  FILE *in = tmpfile ();
+  fputs ("42\n", in);
+  rewind (in);
+  basic_num_t x;
+  assert (BASIC_NUM_SCAN (in, &x));
+  assert (BASIC_TO_INT (x) == 42);
+  fclose (in);
+
+  FILE *bad = tmpfile ();
+  fputs ("oops\n", bad);
+  rewind (bad);
+  assert (!BASIC_NUM_SCAN (bad, &x));
+  fclose (bad);
+  (void) x;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Read numeric input via `fgets` and parse with `BASIC_STRTOF`/`fixed64_from_string`
- Add shared `basic_read_num` helper and update `basic_input`/`basic_input_hash`
- Introduce unit test covering valid and invalid numeric scans

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689ca3915dd08326aaf424e9247df417