### PR TITLE
Handle CRLF line endings in BASIC loader

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -3029,7 +3029,7 @@ static int load_program (LineVec *prog, const char *path) {
   char line[256];
   int ok = 1;
   while (fgets (line, sizeof (line), f)) {
-    line[strcspn (line, "\n")] = '\0';
+    line[strcspn (line, "\r\n")] = '\0';
     Parser p_obj = {0};
     Parser *p = &p_obj;
     p->cur = line;


### PR DESCRIPTION
## Summary
- trim both `\r` and `\n` when reading BASIC source lines to avoid leftover carriage returns

## Testing
- `make basic-test`
- `printf '10 PRINT "HI"\r\n20 IF 1 = THEN\r\n' > /tmp/crlf.bas && ./basic/basicc /tmp/crlf.bas >/tmp/crlf.out 2>&1 && cat -v /tmp/crlf.out`


------
https://chatgpt.com/codex/tasks/task_e_689caa871c548326827f529473025095