### PR TITLE
Provide basic_num_scan wrapper for fixed64 numbers

### DIFF
--- a/basic/docs/README
+++ b/basic/docs/README
@@ -181,6 +181,6 @@ Fixed-Point Variant
 -------------------
 For targets lacking floating-point support, the runtime can be built with
 `-DBASIC_USE_FIXED64` to use a 64.64 fixed-point representation. Arithmetic and
-I/O rely on helper macros such as `BASIC_ADD`, `BASIC_LT`, and `BASIC_NUM_SCAN`
-which wrap the underlying `fixed64` routines.
+I/O rely on helper functions such as `basic_num_add`, `basic_num_lt`, and
+`basic_num_scan` which wrap the underlying `fixed64` routines.
 

--- a/basic/include/basic_num.h
+++ b/basic/include/basic_num.h
@@ -128,7 +128,7 @@ static inline int BASIC_GE (basic_num_t a, basic_num_t b) { return BASIC_LE (b, 
 static inline int basic_num_to_chars (basic_num_t x, char *buf, size_t size) {
   return fixed64_to_string (x, buf, size);
 }
-static inline int BASIC_NUM_SCAN (FILE *f, basic_num_t *out) {
+static inline int basic_num_scan (FILE *f, basic_num_t *out) {
   char buf[128], *end;
   if (fgets (buf, sizeof (buf), f) == NULL) return 0;
   *out = fixed64_from_string (buf, &end);
@@ -283,7 +283,7 @@ static inline int basic_num_ge (basic_num_t a, basic_num_t b) { return BASIC_GE 
 
 #if !defined(BASIC_USE_FIXED64)
 
-static inline int BASIC_NUM_SCAN (FILE *f, basic_num_t *out) {
+static inline int basic_num_scan (FILE *f, basic_num_t *out) {
   char buf[128], *end;
   if (fgets (buf, sizeof (buf), f) == NULL) return 0;
   *out = BASIC_STRTOF (buf, &end);

--- a/basic/test/basic_num_scan_test.c
+++ b/basic/test/basic_num_scan_test.c
@@ -8,14 +8,14 @@ int main (void) {
   fputs ("42\n", in);
   rewind (in);
   basic_num_t x;
-  assert (BASIC_NUM_SCAN (in, &x));
-  assert (BASIC_TO_INT (x) == 42);
+  assert (basic_num_scan (in, &x));
+  assert (basic_num_to_int (x) == 42);
   fclose (in);
 
   FILE *bad = tmpfile ();
   fputs ("oops\n", bad);
   rewind (bad);
-  assert (!BASIC_NUM_SCAN (bad, &x));
+  assert (!basic_num_scan (bad, &x));
   fclose (bad);
   (void) x;
   return 0;


### PR DESCRIPTION
## Summary
- rename BASIC_NUM_SCAN to basic_num_scan and implement it with fixed64_from_string/fixed64_to_string conversions
- update tests and documentation to use new basic_num_scan and numeric helper APIs

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689cac121efc83269ec5b8b97dff19c2