### PR TITLE
Use buffered numeric parsing for BASIC input

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -463,6 +463,14 @@ $(BUILD_DIR)/basic/hcolor_test$(EXE): \
         $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
         $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
+$(BUILD_DIR)/basic/basic_input_hash_test$(EXE): \
+        $(SRC_DIR)/basic/test/basic_input_hash_test.c \
+        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
+
 $(BUILD_DIR)/basic/dfp_test$(EXE): \
         $(SRC_DIR)/basic/test/dfp_test.c \
         $(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
@@ -496,8 +504,8 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) -DBASIC_USE_FIXED64 $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
-	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
+		$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
@@ -505,6 +513,7 @@ basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUI
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out
 	$(BUILD_DIR)/basic/fixed64_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_scan_test$(EXE)
+	$(BUILD_DIR)/basic/basic_input_hash_test$(EXE)
 
 # ------------------ MIR interp tests --------------------------
 .PHONY: clean-mir-interp-tests

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -267,17 +267,9 @@ static char *next_input_field (void) {
   }
 }
 
-static int basic_read_num (FILE *f, basic_num_t *out) {
-  char buf[128], *end;
-  if (fgets (buf, sizeof (buf), f) == NULL) return 0;
-  *out = BASIC_STRTOF (buf, &end);
-  if (end == buf) return 0;
-  return 1;
-}
-
 basic_num_t basic_input (void) {
-  basic_num_t x = BASIC_ZERO; 
-  if (!basic_read_num (stdin, &x)) return BASIC_ZERO;
+  basic_num_t x = BASIC_ZERO;
+  if (!basic_num_scan (stdin, &x)) return BASIC_ZERO;
   return x;
 }
 
@@ -383,7 +375,7 @@ basic_num_t basic_input_hash (basic_num_t n) {
   int idx = basic_num_to_int (n);
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return BASIC_ZERO;
   basic_num_t x = BASIC_ZERO;
-  if (!basic_read_num (basic_files[idx], &x)) return BASIC_ZERO;
+  if (!basic_num_scan (basic_files[idx], &x)) return BASIC_ZERO;
   return x;
 }
 

--- a/basic/test/basic_input_hash_test.c
+++ b/basic/test/basic_input_hash_test.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "basic_num.h"
+
+void basic_open (basic_num_t n, const char *path);
+void basic_close (basic_num_t n);
+basic_num_t basic_input_hash (basic_num_t n);
+
+int main (void) {
+  char path[] = "basic_input_hash_testXXXXXX";
+  int fd = mkstemp (path);
+  FILE *f = fdopen (fd, "w");
+  fputs ("42\n", f);
+  fclose (f);
+
+  basic_open (basic_num_from_int (1), path);
+  basic_num_t x = basic_input_hash (basic_num_from_int (1));
+  basic_close (basic_num_from_int (1));
+  unlink (path);
+  assert (basic_num_to_int (x) == 42);
+
+  char path2[] = "basic_input_hash_badXXXXXX";
+  int fd2 = mkstemp (path2);
+  FILE *f2 = fdopen (fd2, "w");
+  fputs ("oops\n", f2);
+  fclose (f2);
+
+  basic_open (basic_num_from_int (1), path2);
+  basic_num_t y = basic_input_hash (basic_num_from_int (1));
+  basic_close (basic_num_from_int (1));
+  unlink (path2);
+  assert (basic_num_to_int (y) == 0);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- read numeric input via buffered strings instead of `scanf`
- add `basic_input_hash` regression test using the new parsing path
- wire the new test into the build

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689caf31f5ec8326bbc1da6030299432