### PR TITLE
Add fixed64 utility functions

### DIFF
--- a/basic/src/vendor/fixed64/fixed64.c
+++ b/basic/src/vendor/fixed64/fixed64.c
@@ -34,6 +34,23 @@ static int ge128 (uint64_t ah, uint64_t al, uint64_t bh, uint64_t bl) {
   return ah > bh || (ah == bh && al >= bl);
 }
 
+fixed64_t fixed64_from_int (int64_t i) {
+  fixed64_t r;
+  r.hi = i;
+  r.lo = 0;
+  return r;
+}
+
+int64_t fixed64_to_int (fixed64_t x) { return x.hi; }
+
+int fixed64_cmp (fixed64_t a, fixed64_t b) {
+  if (a.hi > b.hi) return 1;
+  if (a.hi < b.hi) return -1;
+  if (a.lo > b.lo) return 1;
+  if (a.lo < b.lo) return -1;
+  return 0;
+}
+
 fixed64_t fixed64_mul (fixed64_t a, fixed64_t b) {
   int neg = (a.hi < 0) ^ (b.hi < 0);
   fixed64_t aa = fixed64_abs (a);
@@ -131,14 +148,6 @@ int fixed64_to_string (fixed64_t x, char *buf, size_t size) {
 fixed64_t fixed64_abs (fixed64_t x) { return x.hi < 0 ? fixed64_neg (x) : x; }
 
 /* CORDIC implementation for trigonometric functions. */
-
-static inline int fixed64_cmp (fixed64_t a, fixed64_t b) {
-  if (a.hi > b.hi) return 1;
-  if (a.hi < b.hi) return -1;
-  if (a.lo > b.lo) return 1;
-  if (a.lo < b.lo) return -1;
-  return 0;
-}
 
 static inline fixed64_t fixed64_shr (fixed64_t x, unsigned n) {
   for (; n; n--) {

--- a/basic/src/vendor/fixed64/fixed64.h
+++ b/basic/src/vendor/fixed64/fixed64.h
@@ -13,14 +13,9 @@ typedef struct {
   int64_t hi;  /* integer part */
 } fixed64_t;
 
-static inline fixed64_t fixed64_from_int (int64_t i) {
-  fixed64_t r;
-  r.hi = i;
-  r.lo = 0;
-  return r;
-}
-
-static inline int64_t fixed64_to_int (fixed64_t x) { return x.hi; }
+fixed64_t fixed64_from_int (int64_t i);
+int64_t fixed64_to_int (fixed64_t x);
+int fixed64_cmp (fixed64_t a, fixed64_t b);
 
 static inline fixed64_t fixed64_neg (fixed64_t a) {
   fixed64_t r;

--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -7,10 +7,13 @@
 int main (void) {
   fixed64_t half = {.hi = 0, .lo = 1ULL << 63};
   fixed64_t quarter = {.hi = 0, .lo = 1ULL << 62};
+  fixed64_t two = fixed64_from_int (2);
+  assert (fixed64_cmp (fixed64_from_int (1), two) < 0);
+  assert (fixed64_cmp (two, fixed64_from_int (1)) > 0);
+  assert (fixed64_cmp (two, two) == 0);
+  assert (fixed64_to_int (two) == 2);
   fixed64_t res = fixed64_add (half, quarter);
   assert (res.hi == 0 && res.lo == ((1ULL << 63) + (1ULL << 62)));
-
-  fixed64_t two = fixed64_from_int (2);
   res = fixed64_sub (two, half);
   assert (res.hi == 1 && res.lo == (1ULL << 63));
 


### PR DESCRIPTION
## Summary
- add `fixed64_from_int`, `fixed64_to_int`, and `fixed64_cmp` to the vendor fixed64 library
- export new fixed64 APIs in the header
- test integer conversion and comparison helpers

## Testing
- `make basic-test` *(fails: bullfight sample segfaults)*
- `make basic/fixed64_test`


------
https://chatgpt.com/codex/tasks/task_e_689cb8fcb16083269f3c072eec16a936