### PR TITLE
Use heap allocation for BASIC variables

### DIFF
--- a/basic/tests/run-tests.sh
+++ b/basic/tests/run-tests.sh
@@ -312,6 +312,10 @@ if [ $rc -eq 139 ]; then
 echo "bullfight sample segfault"
 exit 1
 fi
+if [ $rc -ne 0 ]; then
+echo "bullfight sample failed with exit code $rc"
+exit 1
+fi
 rm -f "$ROOT/basic/bullfight.err"
 echo "bullfight sample OK"
 


### PR DESCRIPTION
## Summary
- Move BASIC variable vector to heap with malloc/realloc
- Free variable vector after program generation and expand function var vectors with heap memory
- Add regression test ensuring bullfight sample runs without crashing

## Testing
- `printf 'NO\n' | ./basic/basicc basic/samples/bcg/bullfight.bas >/tmp/bullfight.out && echo RUN_OK` *(fails: segmentation fault)*
- `make basic-test` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689cb8b21af88326937c5b0039bf7c3a