### PR TITLE
Ensure pool allocations honor numeric alignment

### DIFF
--- a/basic/src/basic_pool.c
+++ b/basic/src/basic_pool.c
@@ -1,4 +1,5 @@
 #include "basic_pool.h"
+#include "basic_num.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -19,10 +20,11 @@ typedef struct FreeBlock {
 static PoolBlock *pool = NULL;
 static FreeBlock *free_list = NULL;
 
-static size_t align_up (size_t n) {
-  size_t align = _Alignof (max_align_t);
-  return (n + align - 1) & ~(align - 1);
-}
+static const size_t alignment = _Alignof (max_align_t) > _Alignof (basic_num_t)
+                                  ? _Alignof (max_align_t)
+                                  : _Alignof (basic_num_t);
+
+static size_t align_up (size_t n) { return (n + alignment - 1) & ~(alignment - 1); }
 
 void basic_pool_init (size_t size) {
   if (pool != NULL) basic_pool_destroy ();

--- a/basic/test/basic_pool_test.c
+++ b/basic/test/basic_pool_test.c
@@ -1,4 +1,5 @@
 #include "basic_pool.h"
+#include "basic_num.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -22,21 +23,17 @@ int main (void) {
   for (int i = 0; i < 4; ++i)
     if (arr2[i] != 0) return 1;
 
-#if defined(BASIC_USE_LONG_DOUBLE)
-  long double *ldarr1 = basic_calloc (4, sizeof (long double));
+  basic_num_t *narr1 = basic_calloc (4, sizeof (basic_num_t));
   for (int i = 0; i < 4; ++i)
-    if (ldarr1[i] != 0.0L) return 1;
-  if ((uintptr_t) ldarr1 % _Alignof (long double) != 0) return 1;
-  basic_pool_free (ldarr1);
-  long double *ldarr2 = basic_calloc (4, sizeof (long double));
-  if (ldarr2 != ldarr1) return 1;
+    if (!BASIC_EQ (narr1[i], BASIC_ZERO)) return 1;
+  if ((uintptr_t) narr1 % _Alignof (basic_num_t) != 0) return 1;
+  basic_pool_free (narr1);
+  basic_num_t *narr2 = basic_calloc (4, sizeof (basic_num_t));
+  if (narr2 != narr1) return 1;
+  for (int i = 0; i < 4; ++i) narr2[i] = BASIC_FROM_INT (i + 1);
+  if (!basic_clear_array_pool (narr2, 4, sizeof (basic_num_t))) return 1;
   for (int i = 0; i < 4; ++i)
-    if (ldarr2[i] != 0.0L) return 1;
-  for (int i = 0; i < 4; ++i) ldarr2[i] = (long double) (i + 1);
-  if (!basic_clear_array_pool (ldarr2, 4, sizeof (long double))) return 1;
-  for (int i = 0; i < 4; ++i)
-    if (ldarr2[i] != 0.0L) return 1;
-#endif
+    if (!BASIC_EQ (narr2[i], BASIC_ZERO)) return 1;
 
   basic_pool_destroy ();
   printf ("basic_pool_test OK\n");


### PR DESCRIPTION
## Summary
- align pool allocations to the greater of `max_align_t` and `basic_num_t`
- test pool alignment for numeric arrays

## Testing
- `make basic-test` *(fails: bullfight sample segfault)*

------
https://chatgpt.com/codex/tasks/task_e_689cc070b40c832697c6f35024cecbb4