### PR TITLE
Add numeric mode CMake options for BASIC example

### DIFF
--- a/.github/workflows/AMD64-Linux-OSX-Windows-test.yml
+++ b/.github/workflows/AMD64-Linux-OSX-Windows-test.yml
@@ -23,3 +23,18 @@ jobs:
         cmake --build . --config Release
         ctest --verbose --output-on-failure
 
+  basic-modes:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [double, long-double, fixed64, msfp]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configure
+      run: cmake -S . -B build -DBUILD_TESTING=ON -DBASIC_NUM_MODE=${{ matrix.mode }}
+    - name: Build
+      run: cmake --build build
+    - name: Test
+      run: ctest --output-on-failure --test-dir build
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if(Threads_FOUND)
   link_libraries(${CMAKE_THREAD_LIBS_INIT})
 endif()
 
+set(BASIC_NUM_MODE "double" CACHE STRING "Numeric mode for BASIC: double, long-double, fixed64, msfp")
+set_property(CACHE BASIC_NUM_MODE PROPERTY STRINGS double long-double fixed64 msfp)
+
 message("C compiler flags: ${CMAKE_C_FLAGS}")
 
 option(BUILD_TESTING "" ON)
@@ -247,4 +250,8 @@ add_test(mir2c-test mir2c_test)
 # ------------------ c2m tests --------------------------
 
 add_test(c2mir-simple-test c2m -v ${PROJECT_SOURCE_DIR}/sieve.c -ei)
+
+if(BUILD_TESTING)
+  add_subdirectory(basic)
+endif()
 

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 3.8)
+project(BASIC C)
+
+set(BASIC_NUM_MODE "double" CACHE STRING "Numeric mode for BASIC: double, long-double, fixed64, msfp")
+set_property(CACHE BASIC_NUM_MODE PROPERTY STRINGS double long-double fixed64 msfp)
+
+set(BASIC_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(BASIC_BASE_SRC
+    src/basicc.c
+    src/basic_runtime.c
+    src/basic_pool.c
+    src/arena.c
+)
+
+set(VENDOR_SRC)
+set(BASICC_NAME "basicc")
+
+if(BASIC_NUM_MODE STREQUAL "long-double")
+  list(APPEND VENDOR_SRC
+       src/vendor/libdfp/decContext.c
+       src/vendor/libdfp/decNumber.c
+       src/vendor/libdfp/decQuad.c
+       src/vendor/ryu/d2s.c
+       src/vendor/ryu/f2s.c
+       src/vendor/ryu/ld2s.c
+       src/vendor/kitty/kitty.c
+       src/vendor/kitty/lodepng.c)
+  set(BASICC_NAME "basicc-ld")
+  add_compile_definitions(BASIC_USE_LONG_DOUBLE)
+elseif(BASIC_NUM_MODE STREQUAL "fixed64")
+  list(APPEND VENDOR_SRC src/vendor/fixed64/fixed64.c)
+  set(BASICC_NAME "basicc-fix")
+  add_compile_definitions(BASIC_USE_FIXED64)
+elseif(BASIC_NUM_MODE STREQUAL "msfp")
+  list(APPEND VENDOR_SRC
+       src/vendor/libdfp/decContext.c
+       src/vendor/libdfp/decNumber.c
+       src/vendor/libdfp/decQuad.c
+       src/vendor/ryu/d2s.c
+       src/vendor/ryu/f2s.c
+       src/vendor/kitty/kitty.c
+       src/vendor/kitty/lodepng.c)
+  set(BASICC_NAME "basicc-msfp")
+  add_compile_definitions(BASIC_USE_MSFP)
+else()
+  list(APPEND VENDOR_SRC
+       src/vendor/libdfp/decContext.c
+       src/vendor/libdfp/decNumber.c
+       src/vendor/libdfp/decQuad.c
+       src/vendor/ryu/d2s.c
+       src/vendor/ryu/f2s.c
+       src/vendor/kitty/kitty.c
+       src/vendor/kitty/lodepng.c)
+  set(BASICC_NAME "basicc")
+  add_compile_definitions(BASIC_USE_DOUBLE)
+endif()
+
+add_executable(${BASICC_NAME} ${BASIC_BASE_SRC} ${VENDOR_SRC})
+
+target_include_directories(${BASICC_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/libdfp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/kitty
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/fixed64
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/ryu)
+
+target_compile_definitions(${BASICC_NAME} PRIVATE BASIC_SRC_DIR=\"${CMAKE_SOURCE_DIR}\")
+
+target_link_libraries(${BASICC_NAME} mir)
+if(UNIX)
+  target_link_libraries(${BASICC_NAME} m)
+endif()
+
+if(BUILD_TESTING)
+  add_test(NAME basic-tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/run-tests.sh $<TARGET_FILE:${BASICC_NAME}>)
+endif()
+

--- a/basic/docs/README
+++ b/basic/docs/README
@@ -28,6 +28,21 @@ invokes each test in both interpreted and JIT-compiled modes and looks for
 `*** TEST PASSED ***` in their output.  Test `P173.BAS` is currently marked as an
 expected failure until TAB error handling is improved.
 
+CMake Numeric Modes
+-------------------
+The BASIC example can also be built with CMake.  Configure with
+`-DBASIC_NUM_MODE=<mode>` to select the numeric representation.  Supported
+values are `double`, `long-double`, `fixed64`, and `msfp`, which map to the
+`BASIC_USE_DOUBLE`, `BASIC_USE_LONG_DOUBLE`, `BASIC_USE_FIXED64`, and
+`BASIC_USE_MSFP` definitions respectively.  For example:
+
+```
+cmake -S . -B build -DBUILD_TESTING=ON -DBASIC_NUM_MODE=fixed64
+cmake --build build
+ctest --output-on-failure --test-dir build
+```
+
+
 The interpreter also recognizes a `CHAIN <expr>` statement that clears the
 current program and loads another BASIC source file.  Because it depends on the
 interpreter runtime, programs containing `CHAIN` are rejected by compilation

--- a/basic/include/basic_num.h
+++ b/basic/include/basic_num.h
@@ -143,7 +143,7 @@ static inline void basic_num_print (FILE *f, basic_num_t x) {
 #define BASIC_NUM_SCANF(f, out) basic_num_scan ((f), (out))
 #define BASIC_NUM_PRINTF(f, x) basic_num_print ((f), (x))
 
-#elif defined(BASIC_USE_DECIMAL128)
+#elif defined(BASIC_USE_DECIMAL128) || defined(BASIC_USE_MSFP)
 #include <dfp/decimal128.h>
 #include <dfp/math.h>
 #include <dfp/stdlib.h>
@@ -192,7 +192,7 @@ static inline int basic_num_to_chars (basic_num_t x, char *buf, size_t size) {
   return (int) strlen (buf);
 }
 
-#else
+#else /* BASIC_USE_DOUBLE or default */
 #include "ryu/ryu.h"
 typedef double basic_num_t;
 #define BASIC_NUM_SCANF "%lf"


### PR DESCRIPTION
## Summary
- add `BASIC_NUM_MODE` option and CMake build for BASIC example
- document numeric mode selection and test in CI

## Testing
- `make basic-test` *(fails: bullfight sample segfault)*
- `cmake -S . -B build -DBUILD_TESTING=ON -DBASIC_NUM_MODE=fixed64 -DLLVM_CONFIG_EXECUTABLE=/nonexistent` *(build failure: llvm2mir.c)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0985bfc832680f98749063a8e1b