### PR TITLE
Ensure basic runtime uses basic_num helpers and aligned pool allocations

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -481,6 +481,11 @@ $(BUILD_DIR)/basic/fixed64_test$(EXE): \
         $(SRC_DIR)/basic/test/fixed64_test.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
+$(BUILD_DIR)/basic/basic_fixed_array_test$(EXE): \
+        $(SRC_DIR)/basic/test/basic_fixed_array_test.c \
+        $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
+
 $(BUILD_DIR)/basic/basic_num_scan_test$(EXE): \
         $(SRC_DIR)/basic/test/basic_num_scan_test.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
@@ -504,14 +509,15 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) -DBASIC_USE_FIXED64 $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
-		$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_fixed_array_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE)
+	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out
 	$(BUILD_DIR)/basic/fixed64_test$(EXE)
+	$(BUILD_DIR)/basic/basic_fixed_array_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_scan_test$(EXE)
 	$(BUILD_DIR)/basic/basic_input_hash_test$(EXE)
 

--- a/basic/src/basic_pool.c
+++ b/basic/src/basic_pool.c
@@ -1,4 +1,5 @@
 #include "basic_pool.h"
+#include "basic_num.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -20,7 +21,9 @@ static PoolBlock *pool = NULL;
 static FreeBlock *free_list = NULL;
 
 static size_t align_up (size_t n) {
-  size_t align = _Alignof (max_align_t);
+  size_t align1 = _Alignof (max_align_t);
+  size_t align2 = _Alignof (basic_num_t);
+  size_t align = align1 > align2 ? align1 : align2;
   return (n + align - 1) & ~(align - 1);
 }
 

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -465,7 +465,7 @@ void *basic_dim_alloc (void *base, basic_num_t len, basic_num_t is_str) {
      ignored here and a new block is always allocated. */
   (void) base;
   size_t n = (size_t) len;
-  size_t elem_size = is_str != 0.0 ? sizeof (char *) : sizeof (basic_num_t);
+  size_t elem_size = basic_num_ne (is_str, BASIC_ZERO) ? sizeof (char *) : sizeof (basic_num_t);
   void *res = basic_alloc_array (n, elem_size, 1);
   if (res == NULL) return NULL;
   return res;
@@ -473,7 +473,7 @@ void *basic_dim_alloc (void *base, basic_num_t len, basic_num_t is_str) {
 
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str) {
   size_t n = (size_t) len;
-  int str_p = is_str != 0.0;
+  int str_p = basic_num_ne (is_str, BASIC_ZERO);
   if (base == NULL || n == 0) return;
   if (str_p) {
     char **sp = (char **) base;
@@ -515,7 +515,7 @@ void basic_tab (basic_num_t n) { printf ("\x1b[%ldG", basic_num_to_int (n)); }
 void basic_htab (basic_num_t n) { basic_tab (n); }
 
 void basic_randomize (basic_num_t n, basic_num_t has_seed) {
-  if (has_seed != 0.0) {
+  if (basic_num_ne (has_seed, BASIC_ZERO)) {
     srand ((unsigned) n);
   } else {
     srand ((unsigned) time (NULL));

--- a/basic/test/basic_fixed_array_test.c
+++ b/basic/test/basic_fixed_array_test.c
@@ -1,0 +1,16 @@
+#define BASIC_USE_FIXED64
+#include "basic_pool.h"
+#include "basic_num.h"
+#include <assert.h>
+#include <stdint.h>
+
+int main (void) {
+  basic_pool_init (0);
+  size_t count = 4;
+  basic_num_t *arr = basic_alloc_array (count, sizeof (basic_num_t), 1);
+  assert (arr != NULL);
+  assert ((uintptr_t) arr % _Alignof (basic_num_t) == 0);
+  basic_pool_free (arr);
+  basic_pool_destroy ();
+  return 0;
+}

--- a/basic/test/basic_pool_test.c
+++ b/basic/test/basic_pool_test.c
@@ -1,4 +1,5 @@
 #include "basic_pool.h"
+#include "basic_num.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -22,21 +23,19 @@ int main (void) {
   for (int i = 0; i < 4; ++i)
     if (arr2[i] != 0) return 1;
 
-#if defined(BASIC_USE_LONG_DOUBLE)
-  long double *ldarr1 = basic_calloc (4, sizeof (long double));
+  basic_num_t *narr1 = basic_calloc (4, sizeof (basic_num_t));
   for (int i = 0; i < 4; ++i)
-    if (ldarr1[i] != 0.0L) return 1;
-  if ((uintptr_t) ldarr1 % _Alignof (long double) != 0) return 1;
-  basic_pool_free (ldarr1);
-  long double *ldarr2 = basic_calloc (4, sizeof (long double));
-  if (ldarr2 != ldarr1) return 1;
+    if (!basic_num_eq (narr1[i], BASIC_ZERO)) return 1;
+  if ((uintptr_t) narr1 % _Alignof (basic_num_t) != 0) return 1;
+  basic_pool_free (narr1);
+  basic_num_t *narr2 = basic_calloc (4, sizeof (basic_num_t));
+  if (narr2 != narr1) return 1;
   for (int i = 0; i < 4; ++i)
-    if (ldarr2[i] != 0.0L) return 1;
-  for (int i = 0; i < 4; ++i) ldarr2[i] = (long double) (i + 1);
-  if (!basic_clear_array_pool (ldarr2, 4, sizeof (long double))) return 1;
+    if (!basic_num_eq (narr2[i], BASIC_ZERO)) return 1;
+  for (int i = 0; i < 4; ++i) narr2[i] = basic_num_from_int (i + 1);
+  if (!basic_clear_array_pool (narr2, 4, sizeof (basic_num_t))) return 1;
   for (int i = 0; i < 4; ++i)
-    if (ldarr2[i] != 0.0L) return 1;
-#endif
+    if (!basic_num_eq (narr2[i], BASIC_ZERO)) return 1;
 
   basic_pool_destroy ();
   printf ("basic_pool_test OK\n");


### PR DESCRIPTION
## Summary
- use `basic_num_ne` instead of comparing to `0.0` for BASIC runtime flags
- align pool allocations to the maximum of `max_align_t` and `basic_num_t`
- rely on `sizeof(basic_num_t)` in array helpers and tests; add fixed-point array alignment test

## Testing
- `make basic-test` *(fails: bullfight sample segfault)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0a71be483268c024d261babe915