### PR TITLE
Refactor numeric handling in BASIC runtime

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -494,8 +494,8 @@ BASIC_NUM_SRCS = \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c
 
 $(BUILD_DIR)/basic/basic_num_scan_test$(EXE): \
-        $(SRC_DIR)/basic/test/basic_num_scan_test.c $(BASIC_NUM_SRCS) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
-
+	$(SRC_DIR)/basic/test/basic_num_scan_test.c $(BASIC_NUM_SRCS) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	
 $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE): \
         $(SRC_DIR)/basic/test/basic_num_fixed64_test.c $(BASIC_NUM_SRCS) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 
@@ -503,6 +503,15 @@ $(BUILD_DIR)/basic/basic_num_mode_switch_test$(EXE): \
         $(SRC_DIR)/basic/test/basic_num_mode_switch_test.c \
         $(SRC_DIR)/basic/src/basic_num_ops.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+
+$(BUILD_DIR)/basic/basic_handle_fixed64_test$(EXE): \
+        $(SRC_DIR)/basic/test/basic_handle_fixed64_test.c \
+        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(BASIC_NUM_SRCS) \
+        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
         $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
@@ -529,7 +538,7 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_handle_fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
 
 run-basic-tests:
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
@@ -542,6 +551,7 @@ run-basic-tests:
 	$(BUILD_DIR)/basic/basic_num_scan_test$(EXE)
 	$(BUILD_DIR)/basic/basic_input_hash_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE)
+	$(BUILD_DIR)/basic/basic_handle_fixed64_test$(EXE)
 
 # ------------------ MIR interp tests --------------------------
 .PHONY: clean-mir-interp-tests

--- a/basic/test/basic_handle_fixed64_test.c
+++ b/basic/test/basic_handle_fixed64_test.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "basic_num.h"
+#include "basic_runtime.h"
+
+int main (void) {
+  basic_num_init (BASIC_NUM_MODE_FIXED64);
+  basic_num_t ctx = basic_mir_ctx ();
+  assert (basic_num_ne (ctx, BASIC_ZERO));
+  basic_num_t ctx2 = basic_mir_ctx ();
+  assert (basic_num_eq (ctx, ctx2));
+
+  basic_num_t mod = basic_mir_mod (ctx, "tmod");
+  assert (basic_num_ne (mod, BASIC_ZERO));
+  basic_num_t func = basic_mir_func (mod, "tfunc", BASIC_ZERO);
+  assert (basic_num_ne (func, BASIC_ZERO));
+  basic_num_t reg = basic_mir_reg (func);
+  basic_num_t lbl = basic_mir_label (func);
+  assert (basic_num_ne (reg, BASIC_ZERO));
+  assert (basic_num_ne (lbl, BASIC_ZERO));
+  basic_mir_emitlbl (func, lbl);
+  basic_mir_ret (func, reg);
+  basic_mir_finish (mod);
+  printf ("basic_handle_fixed64_test OK\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- standardize numeric conversions and comparisons across BASIC runtime helpers
- simplify plotting and graphics routines via basic_num helpers
- validate MIR handle creation and lookup under fixed-point numeric mode

## Testing
- `make basic-test` *(fails: incompatible type for argument 1 of ‘basic_num.lt’)*

------
https://chatgpt.com/codex/tasks/task_e_689cc928fc808326b5e0485412106bcd