### PR TITLE
Reorder basicc includes

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -1,7 +1,7 @@
+#include "basic_num.h"
 #include "mir.h"
 #include "mir-gen.h"
 #include "basic_runtime.h"
-#include "basic_num.h"
 #include "arena.h"
 #include "basic_pool.h"
 


### PR DESCRIPTION
## Summary
- include `basic_num.h` before MIR headers in `basicc.c`

## Testing
- `make basic-test` *(fails: request for member 'f64' in something not a structure or union)*

------
https://chatgpt.com/codex/tasks/task_e_689d0c80bef483268b30da26c624b39e