### PR TITLE
Avoid null dereference in basic_print_str

### DIFF
--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -281,6 +281,7 @@ void basic_print (basic_num_t x) {
 }
 
 void basic_print_str (const char *s) {
+  if (!s) s = "";
   for (const char *p = s; *p != '\0'; p++) basic_pos_val = *p == '\n' ? 1 : basic_pos_val + 1;
   fputs (s, stdout);
 }


### PR DESCRIPTION
## Summary
- Guard against NULL input in `basic_print_str`

## Testing
- `make basic-test` (fails: bullfight sample segfault)


------
https://chatgpt.com/codex/tasks/task_e_689d76cca8c08326a67293057c0891ad