### PR TITLE
Add basic_num_fixed64_test CMake target

### DIFF
--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -76,6 +76,18 @@ if(UNIX)
 endif()
 
 if(BUILD_TESTING)
+  add_executable(basic_num_fixed64_test
+    test/basic_num_fixed64_test.c
+    src/vendor/fixed64/fixed64.c)
+  target_compile_definitions(basic_num_fixed64_test PRIVATE BASIC_USE_FIXED64)
+  target_include_directories(basic_num_fixed64_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/fixed64)
+  if(UNIX)
+    target_link_libraries(basic_num_fixed64_test m)
+  endif()
+  add_test(NAME basic_num_fixed64_test COMMAND basic_num_fixed64_test)
   add_test(NAME basic-tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/run-tests.sh $<TARGET_FILE:${BASICC_NAME}>)
 endif()
-


### PR DESCRIPTION
## Summary
- Add CMake target `basic_num_fixed64_test` that builds the fixed64 numeric unit test with the proper include directories and BASIC_USE_FIXED64 definition
- Register the test with CTest so it can be run via `ctest`

## Testing
- `clang-format -i basic/CMakeLists.txt`
- `make basic-test` *(fails: bullfight sample segfault)*
- `cmake --build build --target basic_num_fixed64_test`
- `cd build && ctest -R basic_num_fixed64_test -V`


------
https://chatgpt.com/codex/tasks/task_e_689d77b0f4c08326a322a312a4fc27f2