### PR TITLE
Define BASIC_USE_FIXED64 in fixed64 test

### DIFF
--- a/basic/test/basic_num_fixed64_test.c
+++ b/basic/test/basic_num_fixed64_test.c
@@ -1,6 +1,9 @@
 #include <assert.h>
 #include <stdio.h>
 
+#ifndef BASIC_USE_FIXED64
+#define BASIC_USE_FIXED64
+#endif
 #include "basic_num.h"
 
 int main (void) {


### PR DESCRIPTION
## Summary
- ensure `basic_num_fixed64_test` uses the fixed64 backend by defining `BASIC_USE_FIXED64` before including `basic_num.h`

## Testing
- `make basic-test` *(fails: segmentation fault in run-basic-tests)*
- `./basic/basic_num_fixed64_test`


------
https://chatgpt.com/codex/tasks/task_e_689d77e19de883269fc4e470b0714f8d