### PR TITLE
Add fixed64 comparison helpers

### DIFF
--- a/basic/src/vendor/fixed64/fixed64.c
+++ b/basic/src/vendor/fixed64/fixed64.c
@@ -51,6 +51,13 @@ int fixed64_cmp (fixed64_t a, fixed64_t b) {
   return 0;
 }
 
+int fixed64_eq (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) == 0; }
+int fixed64_ne (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) != 0; }
+int fixed64_lt (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) < 0; }
+int fixed64_le (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) <= 0; }
+int fixed64_gt (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) > 0; }
+int fixed64_ge (fixed64_t a, fixed64_t b) { return fixed64_cmp (a, b) >= 0; }
+
 fixed64_t fixed64_mul (fixed64_t a, fixed64_t b) {
   int neg = (a.hi < 0) ^ (b.hi < 0);
   fixed64_t aa = fixed64_abs (a);

--- a/basic/src/vendor/fixed64/fixed64.h
+++ b/basic/src/vendor/fixed64/fixed64.h
@@ -16,6 +16,12 @@ typedef struct {
 fixed64_t fixed64_from_int (int64_t i);
 int64_t fixed64_to_int (fixed64_t x);
 int fixed64_cmp (fixed64_t a, fixed64_t b);
+int fixed64_eq (fixed64_t a, fixed64_t b);
+int fixed64_ne (fixed64_t a, fixed64_t b);
+int fixed64_lt (fixed64_t a, fixed64_t b);
+int fixed64_le (fixed64_t a, fixed64_t b);
+int fixed64_gt (fixed64_t a, fixed64_t b);
+int fixed64_ge (fixed64_t a, fixed64_t b);
 
 static inline fixed64_t fixed64_neg (fixed64_t a) {
   fixed64_t r;

--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -15,6 +15,16 @@ int main (void) {
   assert (fixed64_cmp (fixed64_from_int (1), two) < 0);
   assert (fixed64_cmp (two, fixed64_from_int (1)) > 0);
   assert (fixed64_cmp (two, two) == 0);
+  assert (fixed64_eq (two, fixed64_from_int (2)));
+  assert (!fixed64_eq (two, fixed64_from_int (3)));
+  assert (fixed64_ne (two, fixed64_from_int (3)));
+  assert (!fixed64_ne (two, fixed64_from_int (2)));
+  assert (fixed64_lt (fixed64_from_int (1), two));
+  assert (fixed64_le (fixed64_from_int (1), two));
+  assert (fixed64_le (two, two));
+  assert (fixed64_gt (two, fixed64_from_int (1)));
+  assert (fixed64_ge (two, fixed64_from_int (1)));
+  assert (fixed64_ge (two, two));
   assert (fixed64_to_int (two) == 2);
   fixed64_t res = fixed64_add (half, quarter);
   assert (res.hi == 0 && res.lo == ((1ULL << 63) + (1ULL << 62)));


### PR DESCRIPTION
## Summary
- add fixed64_eq/ne/lt/le/gt/ge that wrap fixed64_cmp
- expose new comparison helpers in fixed64.h
- test fixed64 comparison helpers

## Testing
- `make basic-test` *(fails: random output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689d7c8db4b083269fd239f4f628e1b6