### PR TITLE
Add unit tests for ld2s conversion

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -483,6 +483,11 @@ $(BUILD_DIR)/basic/fixed64_test$(EXE): \
         $(SRC_DIR)/basic/test/fixed64_test.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
+$(BUILD_DIR)/basic/ld2s_test$(EXE): \
+        $(SRC_DIR)/basic/test/ld2s_test.c \
+        $(SRC_DIR)/basic/src/vendor/ryu/generic_128.c \
+        $(SRC_DIR)/basic/src/vendor/ryu/ld2s.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
+
 BASIC_NUM_SRCS = \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c
 
@@ -518,7 +523,7 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
         $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/ld2s_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
 
 run-basic-tests:
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
@@ -528,6 +533,7 @@ run-basic-tests:
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out
 	$(BUILD_DIR)/basic/fixed64_test$(EXE)
+	$(BUILD_DIR)/basic/ld2s_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_scan_test$(EXE)
 	$(BUILD_DIR)/basic/basic_input_hash_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE)

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -90,5 +90,16 @@ if(BUILD_TESTING)
     target_link_libraries(basic_num_fixed64_test m)
   endif()
   add_test(NAME basic_num_fixed64_test COMMAND basic_num_fixed64_test)
+
+  add_executable(ld2s_test
+    test/ld2s_test.c
+    src/vendor/ryu/generic_128.c
+    src/vendor/ryu/ld2s.c)
+  target_include_directories(ld2s_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor)
+  if(UNIX)
+    target_link_libraries(ld2s_test m)
+  endif()
+  add_test(NAME ld2s_test COMMAND ld2s_test)
   add_test(NAME basic-tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/run-tests.sh $<TARGET_FILE:${BASICC_NAME}>)
 endif()

--- a/basic/test/ld2s_test.c
+++ b/basic/test/ld2s_test.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ryu/ld2s.h"
+
+int main (void) {
+  char buf[64];
+
+  ld2s_buffered (0.0L, buf);
+  assert (strcmp (buf, "0E0") == 0);
+
+  ld2s_buffered (1.0L, buf);
+  assert (strcmp (buf, "1E0") == 0);
+
+  ld2s_buffered (-1.0L, buf);
+  assert (strcmp (buf, "-1E0") == 0);
+
+  ld2s_buffered (123.456L, buf);
+  assert (strcmp (buf, "1.23456E2") == 0);
+
+  ld2s_buffered (1e30L, buf);
+  assert (strcmp (buf, "1E30") == 0);
+
+  ld2s_buffered (-1e-30L, buf);
+  assert (strcmp (buf, "-1E-30") == 0);
+
+  char *s = ld2s (1.2345L);
+  assert (strcmp (s, "1.2345E0") == 0);
+  free (s);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add long double string conversion tests in vendor Ryu
- integrate ld2s test into make and CMake test harnesses

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689d983ec1b8832694c0a39c3774476c