### PR TITLE
Support fixed64 MIR blocks

### DIFF
--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -26,6 +26,7 @@
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define BASIC_MIR_NUM_T MIR_T_LD
 #define BASIC_MIR_new_num_op MIR_new_ldouble_op
+#define BASIC_MIR_ARG(name) (MIR_var_t){BASIC_MIR_NUM_T, name, 0}
 #define BASIC_MIR_D2I MIR_LD2I
 #define BASIC_MIR_I2D MIR_I2LD
 #define BASIC_MIR_DMOV MIR_LDMOV
@@ -49,6 +50,8 @@
 #elif defined(BASIC_USE_FIXED64)
 #define BASIC_MIR_NUM_T MIR_T_BLK
 #define BASIC_MIR_new_num_op(ctx, v) MIR_new_int_op (ctx, 0)
+#define BASIC_MIR_ARG(name) \
+  (MIR_var_t) { BASIC_MIR_NUM_T, name, sizeof (basic_num_t) }
 #define BASIC_MIR_D2I MIR_D2I
 #define BASIC_MIR_I2D MIR_I2D
 #define BASIC_MIR_DMOV MIR_DMOV
@@ -72,6 +75,7 @@
 #else
 #define BASIC_MIR_NUM_T MIR_T_D
 #define BASIC_MIR_new_num_op MIR_new_double_op
+#define BASIC_MIR_ARG(name) (MIR_var_t){BASIC_MIR_NUM_T, name, 0}
 #define BASIC_MIR_D2I MIR_D2I
 #define BASIC_MIR_I2D MIR_I2D
 #define BASIC_MIR_DMOV MIR_DMOV
@@ -1284,8 +1288,7 @@ basic_num_t basic_mir_func (basic_num_t mod_h, const char *name, basic_num_t nar
     size_t len = snprintf (NULL, 0, "a%zu", i);
     char *arg_name = basic_alloc_string (len);
     snprintf (arg_name, len + 1, "a%zu", i);
-    vars[i].type = BASIC_MIR_NUM_T;
-    vars[i].name = arg_name;
+    vars[i] = BASIC_MIR_ARG (arg_name);
   }
   MIR_item_t func = MIR_new_func_arr (ctx, name, 1, &res, nargs, vars);
   FuncHandle *fh = basic_pool_alloc (sizeof (FuncHandle));

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -5,9 +5,10 @@
 #include "arena.h"
 #include "basic_pool.h"
 
+/* Numeric MIR helpers depending on the selected BASIC number type.  */
 #if defined(BASIC_USE_LONG_DOUBLE)
-#define MIR_T_D MIR_T_LD
-#define MIR_new_double_op MIR_new_ldouble_op
+#define BASIC_MIR_NUM_T MIR_T_LD
+#define BASIC_MIR_new_num_op MIR_new_ldouble_op
 #define MIR_D2I MIR_LD2I
 #define MIR_I2D MIR_I2LD
 #define MIR_DMOV MIR_LDMOV
@@ -28,6 +29,19 @@
 #define MIR_DBLE MIR_LDBLE
 #define MIR_DBGT MIR_LDBGT
 #define MIR_DBGE MIR_LDBGE
+#elif defined(BASIC_USE_FIXED64)
+#define BASIC_MIR_NUM_T MIR_T_BLK
+#define BASIC_MIR_new_num_op(ctx, v) MIR_new_int_op (ctx, 0)
+#else
+#define BASIC_MIR_NUM_T MIR_T_D
+#define BASIC_MIR_new_num_op MIR_new_double_op
+#endif
+
+#if defined(BASIC_USE_FIXED64)
+#define BASIC_MIR_NUM_VAR(name) \
+  (MIR_var_t) { BASIC_MIR_NUM_T, (name), sizeof (basic_num_t) }
+#else
+#define BASIC_MIR_NUM_VAR(name) (MIR_var_t){BASIC_MIR_NUM_T, (name), 0}
 #endif
 
 static MIR_insn_t basic_mir_binop (MIR_context_t ctx, MIR_insn_code_t code, MIR_op_t dst,
@@ -142,12 +156,6 @@ static void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t 
   MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, label, src1, src2));
 #endif
 }
-
-#if defined(BASIC_USE_FIXED64)
-#define BASIC_MIR_NUM_T MIR_T_BLK
-#else
-#define BASIC_MIR_NUM_T MIR_T_D
-#endif
 
 #include <ctype.h>
 #include <stdio.h>
@@ -3346,13 +3354,13 @@ static void ensure_array_dim (VarVec *vars, MIR_context_t ctx, MIR_item_t func, 
   MIR_reg_t len = MIR_new_func_reg (ctx, func->u.func, BASIC_MIR_NUM_T, buf);
   MIR_append_insn (ctx, func,
                    MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, len),
-                                 MIR_new_double_op (ctx, (basic_num_t) asize)));
+                                 BASIC_MIR_new_num_op (ctx, (basic_num_t) asize)));
   MIR_append_insn (ctx, func,
                    MIR_new_call_insn (ctx, 6, MIR_new_ref_op (ctx, dim_alloc_proto),
                                       MIR_new_ref_op (ctx, dim_alloc_import),
                                       MIR_new_reg_op (ctx, base), MIR_new_reg_op (ctx, base),
                                       MIR_new_reg_op (ctx, len),
-                                      MIR_new_double_op (ctx, (basic_num_t) is_str)));
+                                      BASIC_MIR_new_num_op (ctx, (basic_num_t) is_str)));
   MIR_append_insn (ctx, func, done);
 }
 
@@ -3551,7 +3559,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
           MIR_reg_t len = gen_expr (ctx, func, vars, n->index);
           len_op = MIR_new_reg_op (ctx, len);
         } else {
-          len_op = MIR_new_double_op (ctx, -1.0);
+          len_op = BASIC_MIR_new_num_op (ctx, -1.0);
         }
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 6, MIR_new_ref_op (ctx, mid_proto),
@@ -3656,7 +3664,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
     MIR_reg_t r = MIR_new_func_reg (ctx, func->u.func, BASIC_MIR_NUM_T, buf);
     MIR_append_insn (ctx, func,
                      MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, r),
-                                   MIR_new_double_op (ctx, n->num)));
+                                   BASIC_MIR_new_num_op (ctx, n->num)));
     return r;
   } else if (n->kind == N_VAR) {
     if (n->index != NULL) {
@@ -3747,7 +3755,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
     MIR_reg_t resi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
     MIR_append_insn (ctx, func,
                      basic_mir_binop (ctx, MIR_DEQ, MIR_new_reg_op (ctx, resi),
-                                      MIR_new_reg_op (ctx, v), MIR_new_double_op (ctx, 0.0)));
+                                      MIR_new_reg_op (ctx, v), BASIC_MIR_new_num_op (ctx, 0.0)));
     safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
     MIR_reg_t resd = MIR_new_func_reg (ctx, func->u.func, BASIC_MIR_NUM_T, buf);
     MIR_append_insn (ctx, func,
@@ -3978,11 +3986,11 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       MIR_reg_t f = gen_expr (ctx, func, vars, n->left);
       MIR_reg_t op = gen_expr (ctx, func, vars, n->right);
       MIR_op_t a = n->index ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->index))
-                            : MIR_new_double_op (ctx, 0.0);
+                            : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_op_t b = n->index2 ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->index2))
-                             : MIR_new_double_op (ctx, 0.0);
+                             : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_op_t c = n->arg4 ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->arg4))
-                           : MIR_new_double_op (ctx, 0.0);
+                           : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_append_insn (ctx, func,
                        MIR_new_call_insn (ctx, 8, MIR_new_ref_op (ctx, mir_emit_proto),
                                           MIR_new_ref_op (ctx, mir_emit_import),
@@ -4013,13 +4021,13 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
     } else if (strcasecmp (n->var, "MIRRUN") == 0) {
       MIR_reg_t f = gen_expr (ctx, func, vars, n->left);
       MIR_op_t a1 = n->right ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->right))
-                             : MIR_new_double_op (ctx, 0.0);
+                             : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_op_t a2 = n->index ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->index))
-                             : MIR_new_double_op (ctx, 0.0);
+                             : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_op_t a3 = n->index2 ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->index2))
-                              : MIR_new_double_op (ctx, 0.0);
+                              : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_op_t a4 = n->arg4 ? MIR_new_reg_op (ctx, gen_expr (ctx, func, vars, n->arg4))
-                            : MIR_new_double_op (ctx, 0.0);
+                            : BASIC_MIR_new_num_op (ctx, 0.0);
       MIR_append_insn (ctx, func,
                        MIR_new_call_insn (ctx, 8, MIR_new_ref_op (ctx, mir_run_proto),
                                           MIR_new_ref_op (ctx, mir_run_import),
@@ -4051,7 +4059,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
         safe_fprintf (stderr, "undefined function %s\n", n->var);
         MIR_append_insn (ctx, func,
                          MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                       MIR_new_double_op (ctx, 0.0)));
+                                       BASIC_MIR_new_num_op (ctx, 0.0)));
         return res;
       }
       MIR_item_t proto = fd->proto;
@@ -4117,7 +4125,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
         safe_fprintf (stderr, "undefined function %s\n", n->var);
         MIR_append_insn (ctx, func,
                          MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                       MIR_new_double_op (ctx, 0.0)));
+                                       BASIC_MIR_new_num_op (ctx, 0.0)));
         return res;
       }
       MIR_item_t proto = fd->proto;
@@ -4172,18 +4180,18 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
     MIR_label_t false_lab = MIR_new_label (ctx);
     MIR_label_t end_lab = MIR_new_label (ctx);
     basic_mir_bcmp (ctx, func, MIR_DBEQ, MIR_new_label_op (ctx, false_lab), MIR_new_reg_op (ctx, l),
-                    MIR_new_double_op (ctx, 0.0));
+                    BASIC_MIR_new_num_op (ctx, 0.0));
     MIR_reg_t r = gen_expr (ctx, func, vars, n->right);
     basic_mir_bcmp (ctx, func, MIR_DBEQ, MIR_new_label_op (ctx, false_lab), MIR_new_reg_op (ctx, r),
-                    MIR_new_double_op (ctx, 0.0));
+                    BASIC_MIR_new_num_op (ctx, 0.0));
     MIR_append_insn (ctx, func,
                      MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                   MIR_new_double_op (ctx, 1.0)));
+                                   BASIC_MIR_new_num_op (ctx, 1.0)));
     MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_JMP, MIR_new_label_op (ctx, end_lab)));
     MIR_append_insn (ctx, func, false_lab);
     MIR_append_insn (ctx, func,
                      MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                   MIR_new_double_op (ctx, 0.0)));
+                                   BASIC_MIR_new_num_op (ctx, 0.0)));
     MIR_append_insn (ctx, func, end_lab);
     return res;
   } else if (n->op == OP_OR) {
@@ -4194,18 +4202,18 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
     MIR_label_t true_lab = MIR_new_label (ctx);
     MIR_label_t end_lab = MIR_new_label (ctx);
     basic_mir_bcmp (ctx, func, MIR_DBNE, MIR_new_label_op (ctx, true_lab), MIR_new_reg_op (ctx, l),
-                    MIR_new_double_op (ctx, 0.0));
+                    BASIC_MIR_new_num_op (ctx, 0.0));
     MIR_reg_t r = gen_expr (ctx, func, vars, n->right);
     basic_mir_bcmp (ctx, func, MIR_DBNE, MIR_new_label_op (ctx, true_lab), MIR_new_reg_op (ctx, r),
-                    MIR_new_double_op (ctx, 0.0));
+                    BASIC_MIR_new_num_op (ctx, 0.0));
     MIR_append_insn (ctx, func,
                      MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                   MIR_new_double_op (ctx, 0.0)));
+                                   BASIC_MIR_new_num_op (ctx, 0.0)));
     MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_JMP, MIR_new_label_op (ctx, end_lab)));
     MIR_append_insn (ctx, func, true_lab);
     MIR_append_insn (ctx, func,
                      MIR_new_insn (ctx, MIR_DMOV, MIR_new_reg_op (ctx, res),
-                                   MIR_new_double_op (ctx, 1.0)));
+                                   BASIC_MIR_new_num_op (ctx, 1.0)));
     MIR_append_insn (ctx, func, end_lab);
     return res;
   } else {
@@ -4217,12 +4225,12 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       MIR_reg_t li = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       MIR_append_insn (ctx, func,
                        basic_mir_binop (ctx, MIR_DNE, MIR_new_reg_op (ctx, li),
-                                        MIR_new_reg_op (ctx, l), MIR_new_double_op (ctx, 0.0)));
+                                        MIR_new_reg_op (ctx, l), BASIC_MIR_new_num_op (ctx, 0.0)));
       safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
       MIR_reg_t ri = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       MIR_append_insn (ctx, func,
                        basic_mir_binop (ctx, MIR_DNE, MIR_new_reg_op (ctx, ri),
-                                        MIR_new_reg_op (ctx, r), MIR_new_double_op (ctx, 0.0)));
+                                        MIR_new_reg_op (ctx, r), BASIC_MIR_new_num_op (ctx, 0.0)));
       safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
       MIR_reg_t resi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       MIR_insn_code_t bop = n->op == OP_AND ? MIR_AND : MIR_OR;
@@ -4932,8 +4940,8 @@ static void gen_stmt (Stmt *s) {
                          MIR_new_call_insn (g_ctx, 5, MIR_new_ref_op (g_ctx, clear_array_proto),
                                             MIR_new_ref_op (g_ctx, clear_array_import),
                                             MIR_new_reg_op (g_ctx, v->reg),
-                                            MIR_new_double_op (g_ctx, (basic_num_t) v->size),
-                                            MIR_new_double_op (g_ctx, (basic_num_t) v->is_str)));
+                                            BASIC_MIR_new_num_op (g_ctx, (basic_num_t) v->size),
+                                            BASIC_MIR_new_num_op (g_ctx, (basic_num_t) v->is_str)));
         MIR_append_insn (g_ctx, g_func,
                          MIR_new_insn (g_ctx, MIR_MOV, MIR_new_reg_op (g_ctx, v->reg),
                                        MIR_new_int_op (g_ctx, 0)));
@@ -4944,7 +4952,7 @@ static void gen_stmt (Stmt *s) {
       } else {
         MIR_append_insn (g_ctx, g_func,
                          MIR_new_insn (g_ctx, MIR_DMOV, MIR_new_reg_op (g_ctx, v->reg),
-                                       MIR_new_double_op (g_ctx, 0.0)));
+                                       BASIC_MIR_new_num_op (g_ctx, 0.0)));
       }
     }
     MIR_append_insn (g_ctx, g_func,
@@ -5086,7 +5094,7 @@ static void gen_stmt (Stmt *s) {
     MIR_label_t neg_step = MIR_new_label (g_ctx);
     MIR_label_t after_cmp = MIR_new_label (g_ctx);
     basic_mir_bcmp (g_ctx, g_func, MIR_DBLT, MIR_new_label_op (g_ctx, neg_step),
-                    MIR_new_reg_op (g_ctx, step), MIR_new_double_op (g_ctx, 0.0));
+                    MIR_new_reg_op (g_ctx, step), BASIC_MIR_new_num_op (g_ctx, 0.0));
     basic_mir_bcmp (g_ctx, g_func, MIR_DBGT, MIR_new_label_op (g_ctx, end_label),
                     MIR_new_reg_op (g_ctx, var), MIR_new_reg_op (g_ctx, end));
     MIR_append_insn (g_ctx, g_func,
@@ -5125,7 +5133,7 @@ static void gen_stmt (Stmt *s) {
     MIR_append_insn (g_ctx, g_func, start_label);
     MIR_reg_t cond = gen_expr (g_ctx, g_func, &g_vars, s->u.expr);
     basic_mir_bcmp (g_ctx, g_func, MIR_DBEQ, MIR_new_label_op (g_ctx, end_label),
-                    MIR_new_reg_op (g_ctx, cond), MIR_new_double_op (g_ctx, 0.0));
+                    MIR_new_reg_op (g_ctx, cond), BASIC_MIR_new_num_op (g_ctx, 0.0));
     break;
   }
   case ST_WEND: {
@@ -5182,7 +5190,7 @@ static void gen_stmt (Stmt *s) {
     if (info.type != LOOP_REPEAT) break;
     MIR_reg_t cond = gen_expr (g_ctx, g_func, &g_vars, s->u.expr);
     basic_mir_bcmp (g_ctx, g_func, MIR_DBEQ, MIR_new_label_op (g_ctx, info.start_label),
-                    MIR_new_reg_op (g_ctx, cond), MIR_new_double_op (g_ctx, 0.0));
+                    MIR_new_reg_op (g_ctx, cond), BASIC_MIR_new_num_op (g_ctx, 0.0));
     MIR_append_insn (g_ctx, g_func, info.end_label);
     break;
   }
@@ -5291,7 +5299,8 @@ static void gen_stmt (Stmt *s) {
     MIR_insn_code_t ic = s->kind == ST_INC ? MIR_DADD : MIR_DSUB;
     MIR_append_insn (g_ctx, g_func,
                      basic_mir_binop (g_ctx, ic, MIR_new_reg_op (g_ctx, v),
-                                      MIR_new_reg_op (g_ctx, v), MIR_new_double_op (g_ctx, 1.0)));
+                                      MIR_new_reg_op (g_ctx, v),
+                                      BASIC_MIR_new_num_op (g_ctx, 1.0)));
     break;
   }
   case ST_GOTO: {
@@ -5347,7 +5356,7 @@ static void gen_stmt (Stmt *s) {
     MIR_label_t next = (n > 0 || s->u.iff.else_stmts.len > 0) ? MIR_new_label (g_ctx) : end;
     MIR_reg_t r = gen_expr (g_ctx, g_func, &g_vars, s->u.iff.cond);
     basic_mir_bcmp (g_ctx, g_func, MIR_DBEQ, MIR_new_label_op (g_ctx, next),
-                    MIR_new_reg_op (g_ctx, r), MIR_new_double_op (g_ctx, 0.0));
+                    MIR_new_reg_op (g_ctx, r), BASIC_MIR_new_num_op (g_ctx, 0.0));
     for (size_t k = 0; k < s->u.iff.then_stmts.len; k++) gen_stmt (&s->u.iff.then_stmts.data[k]);
     if (n > 0 || s->u.iff.else_stmts.len > 0)
       MIR_append_insn (g_ctx, g_func, MIR_new_insn (g_ctx, MIR_JMP, MIR_new_label_op (g_ctx, end)));
@@ -5357,7 +5366,7 @@ static void gen_stmt (Stmt *s) {
       MIR_label_t next2 = (i + 1 < n || s->u.iff.else_stmts.len > 0) ? MIR_new_label (g_ctx) : end;
       MIR_reg_t ri = gen_expr (g_ctx, g_func, &g_vars, ei->cond);
       basic_mir_bcmp (g_ctx, g_func, MIR_DBEQ, MIR_new_label_op (g_ctx, next2),
-                      MIR_new_reg_op (g_ctx, ri), MIR_new_double_op (g_ctx, 0.0));
+                      MIR_new_reg_op (g_ctx, ri), BASIC_MIR_new_num_op (g_ctx, 0.0));
       for (size_t k = 0; k < ei->stmts.len; k++) gen_stmt (&ei->stmts.data[k]);
       MIR_append_insn (g_ctx, g_func, MIR_new_insn (g_ctx, MIR_JMP, MIR_new_label_op (g_ctx, end)));
       if (next2 != end) MIR_append_insn (g_ctx, g_func, next2);
@@ -5763,10 +5772,10 @@ static void gen_stmt (Stmt *s) {
     if (s->u.expr != NULL) {
       MIR_reg_t seed = gen_expr (g_ctx, g_func, &g_vars, s->u.expr);
       seed_op = MIR_new_reg_op (g_ctx, seed);
-      has_seed_op = MIR_new_double_op (g_ctx, 1.0);
+      has_seed_op = BASIC_MIR_new_num_op (g_ctx, 1.0);
     } else {
-      seed_op = MIR_new_double_op (g_ctx, 0.0);
-      has_seed_op = MIR_new_double_op (g_ctx, 0.0);
+      seed_op = BASIC_MIR_new_num_op (g_ctx, 0.0);
+      has_seed_op = BASIC_MIR_new_num_op (g_ctx, 0.0);
     }
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 4, MIR_new_ref_op (g_ctx, randomize_proto),
@@ -5778,7 +5787,7 @@ static void gen_stmt (Stmt *s) {
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, on_error_proto),
                                         MIR_new_ref_op (g_ctx, on_error_import),
-                                        MIR_new_double_op (g_ctx, (basic_num_t) s->u.target)));
+                                        BASIC_MIR_new_num_op (g_ctx, (basic_num_t) s->u.target)));
     break;
   }
   case ST_RESUME: {
@@ -5942,8 +5951,8 @@ static void gen_stmt (Stmt *s) {
                                           MIR_new_reg_op (g_ctx, base),
                                           MIR_new_reg_op (g_ctx, base),
                                           MIR_new_reg_op (g_ctx, totald),
-                                          MIR_new_double_op (g_ctx,
-                                                             (basic_num_t) s->u.dim.is_str[k])));
+                                          BASIC_MIR_new_num_op (g_ctx,
+                                                                (basic_num_t) s->u.dim.is_str[k])));
     }
     break;
   }
@@ -6490,7 +6499,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   MIR_append_insn (g_ctx, g_func,
                    MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, line_track_proto),
                                       MIR_new_ref_op (g_ctx, line_track_import),
-                                      MIR_new_double_op (g_ctx, (basic_num_t) g_line_tracking)));
+                                      BASIC_MIR_new_num_op (g_ctx, (basic_num_t) g_line_tracking)));
 
   /* create labels for lines */
   size_t n = prog->len;
@@ -6506,12 +6515,12 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
       MIR_append_insn (g_ctx, g_func,
                        MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, profile_line_proto),
                                           MIR_new_ref_op (g_ctx, profile_line_import),
-                                          MIR_new_double_op (g_ctx, (basic_num_t) ln->line)));
+                                          BASIC_MIR_new_num_op (g_ctx, (basic_num_t) ln->line)));
     if (g_line_tracking)
       MIR_append_insn (g_ctx, g_func,
                        MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, set_line_proto),
                                           MIR_new_ref_op (g_ctx, set_line_import),
-                                          MIR_new_double_op (g_ctx, (basic_num_t) ln->line)));
+                                          BASIC_MIR_new_num_op (g_ctx, (basic_num_t) ln->line)));
     for (size_t j = 0; j < ln->stmts.len; j++) {
       gen_stmt (&ln->stmts.data[j]);
     }


### PR DESCRIPTION
## Summary
- Add fixed64-aware MIR helpers and operand macros
- Use numeric macros in BASIC compiler and runtime

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689da630d56c832689467b1fb8a36cac