### PR TITLE
Add terminal-driven SOUND support

### DIFF
--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -1166,9 +1166,20 @@ void basic_beep (void) {
 }
 
 void basic_sound (basic_num_t f, basic_num_t d) {
-  (void) f;
-  (void) d;
-  basic_beep ();
+#if defined(_WIN32)
+  Beep ((DWORD) basic_num_to_int (f), (DWORD) basic_num_to_int (d));
+#else
+  int freq = basic_num_to_int (f);
+  int dur = basic_num_to_int (d);
+  if (freq > 0) {
+    fprintf (stdout, "\033[10;%d]", freq);
+  }
+  if (dur > 0) {
+    fprintf (stdout, "\033[11;%d]", dur);
+  }
+  fputc ('\a', stdout);
+  fflush (stdout);
+#endif
 }
 
 basic_num_t basic_system (const char *cmd) {


### PR DESCRIPTION
## Summary
- implement BASIC SOUND using ANSI escape codes to set tone frequency and duration

## Testing
- `make basic-test` *(fails: runtime error: unsupported fixed64 operation)*

------
https://chatgpt.com/codex/tasks/task_e_689de390da2c8326a7d5f7a2a7966f25