### PR TITLE
fixed64: add ceil and fmod with tests

### DIFF
--- a/basic/src/vendor/fixed64/fixed64.c
+++ b/basic/src/vendor/fixed64/fixed64.c
@@ -264,9 +264,24 @@ fixed64_t fixed64_pow (fixed64_t a, fixed64_t b) {
   return fixed64_from_double (pow (da, db));
 }
 
+fixed64_t fixed64_fmod (fixed64_t a, fixed64_t b) {
+  double da = fixed64_to_double (a);
+  double db = fixed64_to_double (b);
+  return fixed64_from_double (fmod (da, db));
+}
+
 fixed64_t fixed64_floor (fixed64_t a) {
-  double da = floor (fixed64_to_double (a));
-  return fixed64_from_double (da);
+  fixed64_t r = a;
+  r.lo = 0;
+  return r;
+}
+
+fixed64_t fixed64_ceil (fixed64_t a) {
+  if (a.lo == 0) return a;
+  fixed64_t r;
+  r.hi = a.hi + 1;
+  r.lo = 0;
+  return r;
 }
 
 fixed64_t fixed64_sinh (fixed64_t a) {

--- a/basic/src/vendor/fixed64/fixed64.h
+++ b/basic/src/vendor/fixed64/fixed64.h
@@ -60,6 +60,8 @@ fixed64_t fixed64_tan (fixed64_t angle);
 fixed64_t fixed64_sqrt (fixed64_t a);
 fixed64_t fixed64_pow (fixed64_t a, fixed64_t b);
 fixed64_t fixed64_floor (fixed64_t a);
+fixed64_t fixed64_ceil (fixed64_t a);
+fixed64_t fixed64_fmod (fixed64_t a, fixed64_t b);
 fixed64_t fixed64_sinh (fixed64_t a);
 fixed64_t fixed64_cosh (fixed64_t a);
 fixed64_t fixed64_tanh (fixed64_t a);

--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -63,6 +63,26 @@ int main (void) {
   fixed64_t three = fixed64_from_int (3);
   res = fixed64_pow (two, three);
   assert (res.hi == 8 && res.lo == 0);
+
+  /* additional math helpers */
+  res = fixed64_log (two);
+  assert (fabs (fixed64_to_double (res) - log (2.0)) < 1e-6);
+  res = fixed64_log2 (two);
+  assert (fabs (fixed64_to_double (res) - 1.0) < 1e-6);
+  res = fixed64_log10 (fixed64_from_int (100));
+  assert (fabs (fixed64_to_double (res) - 2.0) < 1e-6);
+  res = fixed64_exp (fixed64_from_int (1));
+  assert (fabs (fixed64_to_double (res) - exp (1.0)) < 1e-6);
+  res = fixed64_floor (fixed64_from_double (1.75));
+  assert (res.hi == 1 && res.lo == 0);
+  res = fixed64_floor (fixed64_from_double (-1.75));
+  assert (res.hi == -2 && res.lo == 0);
+  res = fixed64_ceil (fixed64_from_double (1.25));
+  assert (res.hi == 2 && res.lo == 0);
+  res = fixed64_ceil (fixed64_from_double (-1.25));
+  assert (res.hi == -1 && res.lo == 0);
+  res = fixed64_fmod (fixed64_from_double (5.5), two);
+  assert (fabs (fixed64_to_double (res) - fmod (5.5, 2.0)) < 1e-6);
 #ifndef _WIN32
   pid_t pid = fork ();
   if (pid == 0) {


### PR DESCRIPTION
## Summary
- add fixed64_fmod and fixed64_ceil helpers
- implement fixed64_floor without double conversions
- test extended fixed64 math helpers

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689df1e0a86083268dfdf8e5faea9b12