### PR TITLE
Add missing fixed64 math functions and tests

### DIFF
--- a/basic/src/vendor/fixed64/fixed64.c
+++ b/basic/src/vendor/fixed64/fixed64.c
@@ -334,6 +334,43 @@ fixed64_t fixed64_exp (fixed64_t a) {
   return fixed64_from_double (exp (da));
 }
 
+fixed64_t fixed64_ceil (fixed64_t a) {
+  double da = fixed64_to_double (a);
+  return fixed64_from_double (ceil (da));
+}
+
+fixed64_t fixed64_trunc (fixed64_t a) {
+  double da = fixed64_to_double (a);
+  return fixed64_from_double (trunc (da));
+}
+
+fixed64_t fixed64_round (fixed64_t a) {
+  double da = fixed64_to_double (a);
+  return fixed64_from_double (round (da));
+}
+
+fixed64_t fixed64_fmod (fixed64_t a, fixed64_t b) {
+  double da = fixed64_to_double (a);
+  double db = fixed64_to_double (b);
+  return fixed64_from_double (fmod (da, db));
+}
+
+fixed64_t fixed64_atan2 (fixed64_t y, fixed64_t x) {
+  double dy = fixed64_to_double (y);
+  double dx = fixed64_to_double (x);
+  return fixed64_from_double (atan2 (dy, dx));
+}
+
+fixed64_t fixed64_log1p (fixed64_t a) {
+  double da = fixed64_to_double (a);
+  return fixed64_from_double (log1p (da));
+}
+
+fixed64_t fixed64_expm1 (fixed64_t a) {
+  double da = fixed64_to_double (a);
+  return fixed64_from_double (expm1 (da));
+}
+
 fixed64_t fixed64_stub_unary (fixed64_t a) {
   (void) a;
   fprintf (stderr, "runtime error: unsupported fixed64 operation\n");

--- a/basic/src/vendor/fixed64/fixed64.h
+++ b/basic/src/vendor/fixed64/fixed64.h
@@ -73,6 +73,13 @@ fixed64_t fixed64_log (fixed64_t a);
 fixed64_t fixed64_log2 (fixed64_t a);
 fixed64_t fixed64_log10 (fixed64_t a);
 fixed64_t fixed64_exp (fixed64_t a);
+fixed64_t fixed64_ceil (fixed64_t a);
+fixed64_t fixed64_trunc (fixed64_t a);
+fixed64_t fixed64_round (fixed64_t a);
+fixed64_t fixed64_fmod (fixed64_t a, fixed64_t b);
+fixed64_t fixed64_atan2 (fixed64_t y, fixed64_t x);
+fixed64_t fixed64_log1p (fixed64_t a);
+fixed64_t fixed64_expm1 (fixed64_t a);
 fixed64_t fixed64_stub_unary (fixed64_t a);
 fixed64_t fixed64_stub_binary (fixed64_t a, fixed64_t b);
 

--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -63,6 +63,32 @@ int main (void) {
   fixed64_t three = fixed64_from_int (3);
   res = fixed64_pow (two, three);
   assert (res.hi == 8 && res.lo == 0);
+
+  fixed64_t five_half = fixed64_from_double (5.5);
+  res = fixed64_ceil (five_half);
+  assert (res.hi == 6 && res.lo == 0);
+  fixed64_t neg_five_half = fixed64_from_double (-5.5);
+  res = fixed64_ceil (neg_five_half);
+  assert (res.hi == -5 && res.lo == 0);
+  res = fixed64_trunc (five_half);
+  assert (res.hi == 5 && res.lo == 0);
+  res = fixed64_round (fixed64_from_double (2.5));
+  assert (res.hi == 3 && res.lo == 0);
+  res = fixed64_round (fixed64_from_double (-2.5));
+  assert (res.hi == -3 && res.lo == 0);
+
+  res = fixed64_fmod (fixed64_from_int (5), fixed64_from_int (2));
+  assert (res.hi == 1 && res.lo == 0);
+
+  res = fixed64_atan2 (fixed64_from_int (1), fixed64_from_int (1));
+  assert (fabs (fixed64_to_double (res) - fixed64_to_double (quarter_pi)) < 1e-6);
+
+  res = fixed64_log1p (zero);
+  assert (res.hi == 0 && res.lo == 0);
+  res = fixed64_log1p (fixed64_from_double (exp (1.0) - 1.0));
+  assert (fabs (fixed64_to_double (res) - 1.0) < 1e-6);
+  res = fixed64_expm1 (fixed64_from_int (1));
+  assert (fabs (fixed64_to_double (res) - (exp (1.0) - 1.0)) < 1e-6);
 #ifndef _WIN32
   pid_t pid = fork ();
   if (pid == 0) {


### PR DESCRIPTION
## Summary
- expand fixed64 support with ceil, trunc, round, fmod, atan2, log1p, and expm1
- test new fixed64 operations alongside existing suite

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689df221b3c08326822e4dc293d8c92b