### PR TITLE
basic: move fixed64 runtime declarations

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -50,6 +50,16 @@ static MIR_op_t emit_num_const (MIR_context_t ctx, basic_num_t v) {
 #endif
 }
 
+#if defined(BASIC_USE_FIXED64)
+static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
+  fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
+  fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
+  fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
+  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_from_string_proto,
+  fixed64_from_string_import, fixed64_to_int_proto, fixed64_to_int_import, fixed64_neg_proto,
+  fixed64_neg_import;
+#endif
+
 static MIR_insn_t basic_mir_binop (MIR_context_t ctx, MIR_insn_code_t code, MIR_op_t dst,
                                    MIR_op_t src1, MIR_op_t src2) {
 #if defined(BASIC_USE_FIXED64)
@@ -585,17 +595,6 @@ static MIR_item_t rnd_proto, rnd_import, chr_proto, chr_import, unichar_proto, u
   mir_label_proto, mir_label_import, mir_emit_proto, mir_emit_import, mir_emitlbl_proto,
   mir_emitlbl_import, mir_ret_proto, mir_ret_import, mir_finish_proto, mir_finish_import,
   mir_run_proto, mir_run_import, mir_dump_proto, mir_dump_import;
-
-#if defined(BASIC_USE_FIXED64)
-static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
-  fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
-  fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
-  fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
-  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_from_string_proto,
-  fixed64_from_string_import, fixed64_to_int_proto, fixed64_to_int_import, fixed64_neg_proto,
-  fixed64_neg_import;
-#endif
-
 static MIR_insn_t basic_mir_i2n (MIR_context_t ctx, MIR_op_t dst, MIR_op_t src) {
 #if defined(BASIC_USE_LONG_DOUBLE)
   return MIR_new_insn (ctx, MIR_I2LD, dst, src);


### PR DESCRIPTION
## Summary
- move fixed64 runtime prototypes above functions that reference them

## Testing
- `make basic-test` *(fails: basic/basicc-fix compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_689df9ec2dc88326a1a5100ec22764dd