### PR TITLE
basic: add safe_snprintf prototype

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -32,6 +32,8 @@
 #define BASIC_MIR_MOV MIR_DMOV
 #endif
 
+static int safe_snprintf (char *buf, size_t size, const char *fmt, ...);
+
 #if defined(BASIC_USE_FIXED64)
 static MIR_op_t emit_fixed64_const (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));


### PR DESCRIPTION
## Summary
- declare `safe_snprintf` near file top to avoid implicit declaration

## Testing
- `make basic-test` *(fails: fixed64 build errors such as `fixed64_add_proto` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_689df9d7d934832682b370ac1817465e