### PR TITLE
Fix fixed64 math function duplication

### DIFF
--- a/basic/src/vendor/fixed64/fixed64.c
+++ b/basic/src/vendor/fixed64/fixed64.c
@@ -264,22 +264,8 @@ fixed64_t fixed64_pow (fixed64_t a, fixed64_t b) {
   return fixed64_from_double (pow (da, db));
 }
 
-fixed64_t fixed64_fmod (fixed64_t a, fixed64_t b) {
-  double da = fixed64_to_double (a);
-  double db = fixed64_to_double (b);
-  return fixed64_from_double (fmod (da, db));
-}
-
 fixed64_t fixed64_floor (fixed64_t a) {
   fixed64_t r = a;
-  r.lo = 0;
-  return r;
-}
-
-fixed64_t fixed64_ceil (fixed64_t a) {
-  if (a.lo == 0) return a;
-  fixed64_t r;
-  r.hi = a.hi + 1;
   r.lo = 0;
   return r;
 }
@@ -347,7 +333,7 @@ fixed64_t fixed64_log10 (fixed64_t a) {
 fixed64_t fixed64_exp (fixed64_t a) {
   double da = fixed64_to_double (a);
   return fixed64_from_double (exp (da));
-
+}
 
 fixed64_t fixed64_ceil (fixed64_t a) {
   double da = fixed64_to_double (a);
@@ -385,5 +371,3 @@ fixed64_t fixed64_expm1 (fixed64_t a) {
   double da = fixed64_to_double (a);
   return fixed64_from_double (expm1 (da));
 }
-
-


### PR DESCRIPTION
## Summary
- Properly close `fixed64_exp`
- Remove duplicate math helper definitions in `fixed64.c`

## Testing
- `make basic-test` *(fails: basic/src/basicc.c:59:13: error: ‘fixed64_add_proto’ undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_689df9c987ec8326aae841e0cabe0702