### PR TITLE
Use MIR data items for fixed64 constants

### DIFF
--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -53,7 +53,8 @@ static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
 static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
   *p = v;
-  return MIR_new_ref_op (ctx, p);
+  MIR_item_t data_item = MIR_new_data (ctx, NULL, MIR_T_U8, sizeof (basic_num_t), p);
+  return MIR_new_ref_op (ctx, data_item);
 }
 #define BASIC_MIR_D2I MIR_D2I
 #define BASIC_MIR_I2D MIR_I2D

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -38,7 +38,8 @@ static int safe_snprintf (char *buf, size_t size, const char *fmt, ...);
 static MIR_op_t emit_fixed64_const (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
   *p = v;
-  return MIR_new_ref_op (ctx, p);
+  MIR_item_t data_item = MIR_new_data (ctx, NULL, MIR_T_U8, sizeof (basic_num_t), p);
+  return MIR_new_ref_op (ctx, data_item);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- allocate fixed-point constants in MIR modules via `MIR_new_data`
- route numeric operands in BASIC runtime through MIR data items for consistent handling

## Testing
- `make basic-test` *(fails: incompatible type assignment in `basicc.c` during `basicc-fix` build)*

------
https://chatgpt.com/codex/tasks/task_e_689dfd044d188326b680f7ac9b1886de