### PR TITLE
Fix fixed64 numeric handling in BASIC interpreter

### DIFF
--- a/basic/test/fixed64_test.c
+++ b/basic/test/fixed64_test.c
@@ -1,8 +1,17 @@
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "fixed64/fixed64.h"
+
+void fixed64_stub_unary (fixed64_t x) {
+  (void) x;
+  abort ();
+}
 
 int main (void) {
   fixed64_t half = {.hi = 0, .lo = 1ULL << 63};
@@ -99,7 +108,6 @@ int main (void) {
   assert (fabs (fixed64_to_double (res) - asin (0.5)) < 1e-6);
 
   (void) res;
-
 
   /* additional math helpers */
   res = fixed64_log (two);


### PR DESCRIPTION
## Summary
- Normalize BASIC AST numeric initialization with BASIC_ZERO
- Convert integer tokens using basic_num_to_int to support fixed64 types
- Add missing headers and stub function for fixed64 tests

## Testing
- `make basic-test` *(fails: wrong result type in proto basic_input_p)*

------
https://chatgpt.com/codex/tasks/task_e_689e021bbd6483269450a75a8924ef2c