### PR TITLE
Refactor BASIC fixed64 support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -447,7 +447,7 @@ $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basicc-fix$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+        $(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_runtime.c \
         $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -29,7 +29,9 @@ if(BASIC_NUM_MODE STREQUAL "long-double")
   set(BASICC_NAME "basicc-ld")
   add_compile_definitions(BASIC_USE_LONG_DOUBLE)
 elseif(BASIC_NUM_MODE STREQUAL "fixed64")
+  list(REMOVE_ITEM BASIC_SRCS src/basicc.c)
   list(APPEND BASIC_SRCS
+       src/basicc_fixed64.c
        src/vendor/fixed64/fixed64.c
        src/vendor/kitty/kitty.c
        src/vendor/kitty/lodepng.c)


### PR DESCRIPTION
## Summary
- split fixed-point BASIC compiler logic into `basicc_fixed64.c`
- streamline default `basicc.c` for double/long double modes
- update build scripts to use the new fixed64 source

## Testing
- `make basic-test` (fails: param of call is of block type but arg is not of block type memory)
- `./basic/tests/run-tests.sh basic/basicc`


------
https://chatgpt.com/codex/tasks/task_e_689eec2bf4f88326821aae3db701d935