### PR TITLE
Refactor BASIC fixed-point runtime

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -448,7 +448,7 @@ $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir
 
 $(BUILD_DIR)/basic/basicc-fix$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
         $(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_runtime.c \
-        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+        $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
 
@@ -523,7 +523,7 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
         $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
         $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
         $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
@@ -531,15 +531,15 @@ $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
         $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
         $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_pool.c \
         $(BASIC_NUM_SRCS) \
         $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
         $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 
 basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/basicc-fix$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/ld2s_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_prng128_test$(EXE) $(BUILD_DIR)/basic/basic_system_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -22,6 +22,7 @@
 #include "kitty/kitty.h"
 #include "basic_runtime.h"
 #include "basic_pool.h"
+#include "basic_runtime_fixed64.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define BASIC_MIR_NUM_T MIR_T_LD
@@ -48,157 +49,8 @@ static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
 #define BASIC_MIR_DBLE MIR_LDBLE
 #define BASIC_MIR_DBGT MIR_LDBGT
 #define BASIC_MIR_DBGE MIR_LDBGE
-#elif defined(BASIC_USE_FIXED64)
-#define BASIC_MIR_NUM_T MIR_T_BLK
-static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
-  basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
-  *p = v;
-  MIR_item_t data_item = MIR_new_data (ctx, NULL, MIR_T_U8, sizeof (basic_num_t), p);
-  return MIR_new_ref_op (ctx, data_item);
-}
-
-static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
-  fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
-  fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
-  fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
-  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_to_int_proto,
-  fixed64_to_int_import, fixed64_neg_proto, fixed64_neg_import;
-
-static MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_type_t t) {
-  MIR_reg_t r;
-  if (op.mode == MIR_OP_REG) {
-    r = op.u.reg;
-  } else {
-    char buf[32];
-    static int addr_id = 0;
-    snprintf (buf, sizeof (buf), "$ba%d", addr_id++);
-    r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-    MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
-  }
-  return MIR_new_mem_op (ctx, t, sizeof (basic_num_t), r, 0, 1);
-}
-
-static MIR_insn_t basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
-                                   MIR_op_t dst, MIR_op_t src1, MIR_op_t src2) {
-  MIR_item_t proto = NULL, import = NULL;
-  switch (code) {
-  case MIR_DADD:
-    proto = fixed64_add_proto;
-    import = fixed64_add_import;
-    break;
-  case MIR_DSUB:
-    proto = fixed64_sub_proto;
-    import = fixed64_sub_import;
-    break;
-  case MIR_DMUL:
-    proto = fixed64_mul_proto;
-    import = fixed64_mul_import;
-    break;
-  case MIR_DDIV:
-    proto = fixed64_div_proto;
-    import = fixed64_div_import;
-    break;
-  case MIR_DEQ:
-    proto = fixed64_eq_proto;
-    import = fixed64_eq_import;
-    break;
-  case MIR_DNE:
-    proto = fixed64_ne_proto;
-    import = fixed64_ne_import;
-    break;
-  case MIR_DLT:
-    proto = fixed64_lt_proto;
-    import = fixed64_lt_import;
-    break;
-  case MIR_DLE:
-    proto = fixed64_le_proto;
-    import = fixed64_le_import;
-    break;
-  case MIR_DGT:
-    proto = fixed64_gt_proto;
-    import = fixed64_gt_import;
-    break;
-  case MIR_DGE:
-    proto = fixed64_ge_proto;
-    import = fixed64_ge_import;
-    break;
-  default: return MIR_new_insn (ctx, code, dst, src1, src2);
-  }
-  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
-  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
-  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
-  return MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto), MIR_new_ref_op (ctx, import),
-                            dst_mem, src1_mem, src2_mem);
-}
-
-static MIR_insn_t basic_mir_unop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
-                                  MIR_op_t dst, MIR_op_t src) {
-  if (code == MIR_DNEG) {
-    MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
-    MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
-    return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_neg_proto),
-                              MIR_new_ref_op (ctx, fixed64_neg_import), dst_mem, src_mem);
-  }
-  return MIR_new_insn (ctx, code, dst, src);
-}
-
-static MIR_insn_t basic_mir_i2n (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
-  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
-  return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_from_int_proto),
-                            MIR_new_ref_op (ctx, fixed64_from_int_import), dst_mem, src);
-}
-
-static MIR_insn_t basic_mir_n2i (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
-  MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
-  return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_to_int_proto),
-                            MIR_new_ref_op (ctx, fixed64_to_int_import), dst, src_mem);
-}
-
-static void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
-                            MIR_op_t label, MIR_op_t src1, MIR_op_t src2) {
-  MIR_item_t proto = NULL, import = NULL;
-  switch (code) {
-  case MIR_DBEQ:
-    proto = fixed64_eq_proto;
-    import = fixed64_eq_import;
-    break;
-  case MIR_DBNE:
-    proto = fixed64_ne_proto;
-    import = fixed64_ne_import;
-    break;
-  case MIR_DBLT:
-    proto = fixed64_lt_proto;
-    import = fixed64_lt_import;
-    break;
-  case MIR_DBLE:
-    proto = fixed64_le_proto;
-    import = fixed64_le_import;
-    break;
-  case MIR_DBGT:
-    proto = fixed64_gt_proto;
-    import = fixed64_gt_import;
-    break;
-  case MIR_DBGE:
-    proto = fixed64_ge_proto;
-    import = fixed64_ge_import;
-    break;
-  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, label, src1, src2)); return;
-  }
-  char buf[32];
-  static int btmp_id = 0;
-  snprintf (buf, sizeof (buf), "$bcmp%d", btmp_id++);
-  MIR_reg_t tmp = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
-  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
-  MIR_append_insn (ctx, func,
-                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto),
-                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, tmp),
-                                      src1_mem, src2_mem));
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_BNE, label, MIR_new_reg_op (ctx, tmp),
-                                 MIR_new_int_op (ctx, 0)));
-}
 #else
+#ifndef BASIC_MIR_NUM_T
 #define BASIC_MIR_NUM_T MIR_T_D
 static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
   return MIR_new_double_op (ctx, v);
@@ -224,17 +76,18 @@ static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
 #define BASIC_MIR_DBGT MIR_DBGT
 #define BASIC_MIR_DBGE MIR_DBGE
 #endif
+#endif
 
-static int seeded = 0;
+int seeded = 0;
 #if defined(BASIC_USE_LONG_DOUBLE) && !defined(BASIC_PRNG128)
 #define BASIC_PRNG128 1
 #endif
 #if defined(BASIC_PRNG128)
-static uint64_t s[4] = {0, 0, 0, 0};
+uint64_t s[4] = {0, 0, 0, 0};
 #else
-static uint64_t rng_state = 0;
+uint64_t rng_state = 0;
 #endif
-static int basic_pos_val = 1;
+int basic_pos_val = 1;
 static int basic_error_handler = 0;
 static int basic_line = 0;
 static basic_num_t last_hplot_x = BASIC_ZERO, last_hplot_y = BASIC_ZERO;
@@ -453,11 +306,7 @@ static char *next_input_field (void) {
   }
 }
 
-#if defined(BASIC_USE_FIXED64)
-void basic_input (basic_num_t *res) {
-  if (!basic_num_scan (stdin, res)) *res = BASIC_ZERO;
-}
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_input (void) {
   basic_num_t x = BASIC_ZERO;
   if (!basic_num_scan (stdin, &x)) return BASIC_ZERO;
@@ -478,9 +327,7 @@ void basic_print_str (const char *s) {
   fputs (s, stdout);
 }
 
-#if defined(BASIC_USE_FIXED64)
-void basic_pos (basic_num_t *res) { *res = basic_num_from_int (basic_pos_val); }
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_pos (void) { return basic_num_from_int (basic_pos_val); }
 #endif
 
@@ -531,7 +378,7 @@ int basic_strcmp (const char *a, const char *b) {
 }
 
 #define BASIC_MAX_FILES 16
-static FILE *basic_files[BASIC_MAX_FILES];
+FILE *basic_files[BASIC_MAX_FILES];
 
 void basic_open (basic_num_t n, const char *path) {
   int idx = basic_num_to_int (n);
@@ -568,16 +415,7 @@ void basic_print_hash_str (basic_num_t n, const char *s) {
   fputs (s, basic_files[idx]);
 }
 
-#if defined(BASIC_USE_FIXED64)
-void basic_input_hash (basic_num_t *res, basic_num_t n) {
-  int idx = basic_num_to_int (n);
-  if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
-    *res = BASIC_ZERO;
-    return;
-  }
-  if (!basic_num_scan (basic_files[idx], res)) *res = BASIC_ZERO;
-}
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_input_hash (basic_num_t n) {
   int idx = basic_num_to_int (n);
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return BASIC_ZERO;
@@ -651,15 +489,7 @@ BasicData *basic_data_items = NULL;
 size_t basic_data_len = 0;
 size_t basic_data_pos = 0;
 
-#if defined(BASIC_USE_FIXED64)
-void basic_read (basic_num_t *res) {
-  if (basic_data_pos >= basic_data_len || basic_data_items[basic_data_pos].is_str) {
-    *res = BASIC_ZERO;
-    return;
-  }
-  *res = basic_data_items[basic_data_pos++].num;
-}
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_read (void) {
   if (basic_data_pos >= basic_data_len || basic_data_items[basic_data_pos].is_str)
     return BASIC_ZERO;
@@ -748,12 +578,12 @@ static uint64_t xoshiro256ss_next (void) {
   return result;
 }
 
-static __uint128_t basic_next_u128 (void) {
+__uint128_t basic_next_u128 (void) {
   __uint128_t hi = (__uint128_t) xoshiro256ss_next () << 64;
   return hi | xoshiro256ss_next ();
 }
 
-static uint64_t splitmix64 (uint64_t *x) {
+uint64_t splitmix64 (uint64_t *x) {
   uint64_t z = (*x += UINT64_C (0x9E3779B97F4A7C15));
   z = (z ^ (z >> 30)) * UINT64_C (0xBF58476D1CE4E5B9);
   z = (z ^ (z >> 27)) * UINT64_C (0x94D049BB133111EB);
@@ -772,26 +602,7 @@ void basic_randomize (basic_num_t n, basic_num_t has_seed) {
   seeded = 1;
 }
 
-#if defined(BASIC_USE_FIXED64)
-void basic_rnd (basic_num_t *res, basic_num_t n) {
-  if (!seeded) {
-    basic_randomize (BASIC_ZERO, BASIC_ZERO);
-  }
-  __uint128_t r = basic_next_u128 ();
-  uint64_t hi = (uint64_t) (r >> 64);
-  uint64_t lo = (uint64_t) r;
-  basic_num_t base = basic_num_from_int ((long) (1ULL << 32));
-  basic_num_t base64 = basic_num_mul (base, base);
-  basic_num_t hi_num = basic_num_add (basic_num_mul (basic_num_from_int ((long) (hi >> 32)), base),
-                                      basic_num_from_int ((long) (hi & UINT32_MAX)));
-  basic_num_t lo_num = basic_num_add (basic_num_mul (basic_num_from_int ((long) (lo >> 32)), base),
-                                      basic_num_from_int ((long) (lo & UINT32_MAX)));
-  basic_num_t frac = basic_num_div (hi_num, base64);
-  basic_num_t base128 = basic_num_mul (base64, base64);
-  frac = basic_num_add (frac, basic_num_div (lo_num, base128));
-  *res = basic_num_mul (frac, n);
-}
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_rnd (basic_num_t n) {
   if (!seeded) {
     basic_randomize (BASIC_ZERO, BASIC_ZERO);
@@ -812,7 +623,7 @@ basic_num_t basic_rnd (basic_num_t n) {
 }
 #endif
 #else
-static uint64_t basic_next_u64 (void) {
+uint64_t basic_next_u64 (void) {
   uint64_t x = rng_state;
   x ^= x >> 12;
   x ^= x << 25;
@@ -830,20 +641,7 @@ void basic_randomize (basic_num_t n, basic_num_t has_seed) {
   seeded = 1;
 }
 
-#if defined(BASIC_USE_FIXED64)
-void basic_rnd (basic_num_t *res, basic_num_t n) {
-  if (!seeded) {
-    basic_randomize (BASIC_ZERO, BASIC_ZERO);
-  }
-  uint64_t r = basic_next_u64 ();
-  basic_num_t hi = basic_num_from_int ((long) (r >> 32));
-  basic_num_t lo = basic_num_from_int ((long) (r & UINT32_MAX));
-  basic_num_t base = basic_num_from_int ((long) (1ULL << 32));
-  basic_num_t frac = basic_num_add (hi, basic_num_div (lo, base));
-  frac = basic_num_div (frac, base);
-  *res = basic_num_mul (frac, n);
-}
-#else
+#ifndef BASIC_USE_FIXED64
 basic_num_t basic_rnd (basic_num_t n) {
   if (!seeded) {
     basic_randomize (BASIC_ZERO, BASIC_ZERO);
@@ -1514,68 +1312,7 @@ basic_num_t basic_mir_mod (basic_num_t ctx_h, const char *name) {
   if (h == NULL || h->kind != H_CTX) return BASIC_ZERO;
   MIR_context_t ctx = h->ctx;
   MIR_module_t mod = MIR_new_module (ctx, name);
-#if defined(BASIC_USE_FIXED64)
-  MIR_type_t blk = MIR_T_BLK;
-  MIR_type_t i64 = MIR_T_I64;
-  MIR_var_t res_arg;
-  res_arg.name = "res";
-  res_arg.type = MIR_T_RBLK;
-  res_arg.size = sizeof (basic_num_t);
-  MIR_var_t bin_vars[3];
-  bin_vars[0] = res_arg;
-  bin_vars[1].name = "a";
-  bin_vars[1].type = MIR_T_BLK;
-  bin_vars[1].size = sizeof (basic_num_t);
-  bin_vars[2].name = "b";
-  bin_vars[2].type = MIR_T_BLK;
-  bin_vars[2].size = sizeof (basic_num_t);
-  fixed64_add_proto = MIR_new_proto_arr (ctx, "fixed64_add_p", 0, NULL, 3, bin_vars);
-  fixed64_add_import = MIR_new_import (ctx, "fixed64_add");
-  fixed64_sub_proto = MIR_new_proto_arr (ctx, "fixed64_sub_p", 0, NULL, 3, bin_vars);
-  fixed64_sub_import = MIR_new_import (ctx, "fixed64_sub");
-  fixed64_mul_proto = MIR_new_proto_arr (ctx, "fixed64_mul_p", 0, NULL, 3, bin_vars);
-  fixed64_mul_import = MIR_new_import (ctx, "fixed64_mul");
-  fixed64_div_proto = MIR_new_proto_arr (ctx, "fixed64_div_p", 0, NULL, 3, bin_vars);
-  fixed64_div_import = MIR_new_import (ctx, "fixed64_div");
-  MIR_var_t un_vars[2];
-  un_vars[0] = res_arg;
-  un_vars[1].name = "a";
-  un_vars[1].type = MIR_T_BLK;
-  un_vars[1].size = sizeof (basic_num_t);
-  fixed64_neg_proto = MIR_new_proto_arr (ctx, "fixed64_neg_p", 0, NULL, 2, un_vars);
-  fixed64_neg_import = MIR_new_import (ctx, "fixed64_neg");
-  MIR_var_t cmp_vars[2];
-  cmp_vars[0].name = "a";
-  cmp_vars[0].type = MIR_T_BLK;
-  cmp_vars[0].size = sizeof (basic_num_t);
-  cmp_vars[1].name = "b";
-  cmp_vars[1].type = MIR_T_BLK;
-  cmp_vars[1].size = sizeof (basic_num_t);
-  fixed64_eq_proto = MIR_new_proto_arr (ctx, "fixed64_eq_p", 1, &i64, 2, cmp_vars);
-  fixed64_eq_import = MIR_new_import (ctx, "fixed64_eq");
-  fixed64_ne_proto = MIR_new_proto_arr (ctx, "fixed64_ne_p", 1, &i64, 2, cmp_vars);
-  fixed64_ne_import = MIR_new_import (ctx, "fixed64_ne");
-  fixed64_lt_proto = MIR_new_proto_arr (ctx, "fixed64_lt_p", 1, &i64, 2, cmp_vars);
-  fixed64_lt_import = MIR_new_import (ctx, "fixed64_lt");
-  fixed64_le_proto = MIR_new_proto_arr (ctx, "fixed64_le_p", 1, &i64, 2, cmp_vars);
-  fixed64_le_import = MIR_new_import (ctx, "fixed64_le");
-  fixed64_gt_proto = MIR_new_proto_arr (ctx, "fixed64_gt_p", 1, &i64, 2, cmp_vars);
-  fixed64_gt_import = MIR_new_import (ctx, "fixed64_gt");
-  fixed64_ge_proto = MIR_new_proto_arr (ctx, "fixed64_ge_p", 1, &i64, 2, cmp_vars);
-  fixed64_ge_import = MIR_new_import (ctx, "fixed64_ge");
-  MIR_var_t int_vars[2];
-  int_vars[0] = res_arg;
-  int_vars[1].name = "i";
-  int_vars[1].type = MIR_T_I64;
-  fixed64_from_int_proto = MIR_new_proto_arr (ctx, "fixed64_from_int_p", 0, NULL, 2, int_vars);
-  fixed64_from_int_import = MIR_new_import (ctx, "fixed64_from_int");
-  MIR_var_t to_int_vars[1];
-  to_int_vars[0].name = "a";
-  to_int_vars[0].type = MIR_T_BLK;
-  to_int_vars[0].size = sizeof (basic_num_t);
-  fixed64_to_int_proto = MIR_new_proto_arr (ctx, "fixed64_to_int_p", 1, &i64, 1, to_int_vars);
-  fixed64_to_int_import = MIR_new_import (ctx, "fixed64_to_int");
-#endif
+  basic_runtime_fixed64_init (ctx);
   return new_handle (H_MOD, ctx, mod);
 }
 
@@ -1657,34 +1394,8 @@ basic_num_t basic_mir_emit (basic_num_t func_h, const char *op, basic_num_t a, b
     else
       ops[i] = BASIC_MIR_new_num_op (ctx, vals[i]);
   }
-#if defined(BASIC_USE_FIXED64)
-  MIR_insn_t insn;
-  switch (code) {
-  case MIR_DADD:
-  case MIR_DSUB:
-  case MIR_DMUL:
-  case MIR_DDIV:
-  case MIR_DEQ:
-  case MIR_DNE:
-  case MIR_DLT:
-  case MIR_DLE:
-  case MIR_DGT:
-  case MIR_DGE: insn = basic_mir_binop (ctx, fh->item, code, ops[0], ops[1], ops[2]); break;
-  case MIR_DNEG: insn = basic_mir_unop (ctx, fh->item, code, ops[0], ops[1]); break;
-  case MIR_I2D: insn = basic_mir_i2n (ctx, fh->item, ops[0], ops[1]); break;
-  case MIR_D2I: insn = basic_mir_n2i (ctx, fh->item, ops[0], ops[1]); break;
-  case MIR_DBEQ:
-  case MIR_DBNE:
-  case MIR_DBLT:
-  case MIR_DBLE:
-  case MIR_DBGT:
-  case MIR_DBGE: basic_mir_bcmp (ctx, fh->item, code, ops[0], ops[1], ops[2]); return BASIC_ZERO;
-  default: insn = MIR_new_insn_arr (ctx, code, nops, ops); break;
-  }
-  MIR_append_insn (ctx, fh->item, insn);
-#else
+  if (basic_mir_emit_fixed64 (ctx, fh->item, code, ops, nops)) return BASIC_ZERO;
   MIR_append_insn (ctx, fh->item, MIR_new_insn_arr (ctx, code, nops, ops));
-#endif
   return BASIC_ZERO;
 }
 

--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -1,0 +1,320 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "basic_runtime_fixed64.h"
+#include "basic_runtime.h"
+#include "basic_num.h"
+
+extern int seeded;
+#if defined(BASIC_PRNG128)
+extern uint64_t s[4];
+__uint128_t basic_next_u128 (void);
+#else
+extern uint64_t rng_state;
+uint64_t basic_next_u64 (void);
+#endif
+void basic_randomize (basic_num_t n, basic_num_t has_seed);
+
+extern int basic_pos_val;
+#define BASIC_MAX_FILES 16
+extern FILE *basic_files[];
+typedef struct BasicData {
+  int is_str;
+  basic_num_t num;
+  char *str;
+} BasicData;
+extern BasicData *basic_data_items;
+extern size_t basic_data_len;
+extern size_t basic_data_pos;
+
+static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
+  fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
+  fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
+  fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
+  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_to_int_proto,
+  fixed64_to_int_import, fixed64_neg_proto, fixed64_neg_import;
+
+static MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_type_t t) {
+  MIR_reg_t r;
+  if (op.mode == MIR_OP_REG) {
+    r = op.u.reg;
+  } else {
+    char buf[32];
+    static int addr_id = 0;
+    snprintf (buf, sizeof (buf), "$ba%d", addr_id++);
+    r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+    MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
+  }
+  return MIR_new_mem_op (ctx, t, sizeof (basic_num_t), r, 0, 1);
+}
+
+static MIR_insn_t basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
+                                   MIR_op_t dst, MIR_op_t src1, MIR_op_t src2) {
+  MIR_item_t proto = NULL, import = NULL;
+  switch (code) {
+  case MIR_DADD:
+    proto = fixed64_add_proto;
+    import = fixed64_add_import;
+    break;
+  case MIR_DSUB:
+    proto = fixed64_sub_proto;
+    import = fixed64_sub_import;
+    break;
+  case MIR_DMUL:
+    proto = fixed64_mul_proto;
+    import = fixed64_mul_import;
+    break;
+  case MIR_DDIV:
+    proto = fixed64_div_proto;
+    import = fixed64_div_import;
+    break;
+  case MIR_DEQ:
+    proto = fixed64_eq_proto;
+    import = fixed64_eq_import;
+    break;
+  case MIR_DNE:
+    proto = fixed64_ne_proto;
+    import = fixed64_ne_import;
+    break;
+  case MIR_DLT:
+    proto = fixed64_lt_proto;
+    import = fixed64_lt_import;
+    break;
+  case MIR_DLE:
+    proto = fixed64_le_proto;
+    import = fixed64_le_import;
+    break;
+  case MIR_DGT:
+    proto = fixed64_gt_proto;
+    import = fixed64_gt_import;
+    break;
+  case MIR_DGE:
+    proto = fixed64_ge_proto;
+    import = fixed64_ge_import;
+    break;
+  default: return MIR_new_insn (ctx, code, dst, src1, src2);
+  }
+  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
+  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
+  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
+  return MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto), MIR_new_ref_op (ctx, import),
+                            dst_mem, src1_mem, src2_mem);
+}
+
+static MIR_insn_t basic_mir_unop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
+                                  MIR_op_t dst, MIR_op_t src) {
+  if (code == MIR_DNEG) {
+    MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
+    MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
+    return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_neg_proto),
+                              MIR_new_ref_op (ctx, fixed64_neg_import), dst_mem, src_mem);
+  }
+  return MIR_new_insn (ctx, code, dst, src);
+}
+
+static MIR_insn_t basic_mir_i2n (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
+  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_RBLK);
+  return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_from_int_proto),
+                            MIR_new_ref_op (ctx, fixed64_from_int_import), dst_mem, src);
+}
+
+static MIR_insn_t basic_mir_n2i (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
+  MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
+  return MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_to_int_proto),
+                            MIR_new_ref_op (ctx, fixed64_to_int_import), dst, src_mem);
+}
+
+static void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
+                            MIR_op_t label, MIR_op_t src1, MIR_op_t src2) {
+  MIR_item_t proto = NULL, import = NULL;
+  switch (code) {
+  case MIR_DBEQ:
+    proto = fixed64_eq_proto;
+    import = fixed64_eq_import;
+    break;
+  case MIR_DBNE:
+    proto = fixed64_ne_proto;
+    import = fixed64_ne_import;
+    break;
+  case MIR_DBLT:
+    proto = fixed64_lt_proto;
+    import = fixed64_lt_import;
+    break;
+  case MIR_DBLE:
+    proto = fixed64_le_proto;
+    import = fixed64_le_import;
+    break;
+  case MIR_DBGT:
+    proto = fixed64_gt_proto;
+    import = fixed64_gt_import;
+    break;
+  case MIR_DBGE:
+    proto = fixed64_ge_proto;
+    import = fixed64_ge_import;
+    break;
+  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, label, src1, src2)); return;
+  }
+  char buf[32];
+  static int btmp_id = 0;
+  snprintf (buf, sizeof (buf), "$bcmp%d", btmp_id++);
+  MIR_reg_t tmp = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
+  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto),
+                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, tmp),
+                                      src1_mem, src2_mem));
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_BNE, label, MIR_new_reg_op (ctx, tmp),
+                                 MIR_new_int_op (ctx, 0)));
+}
+
+void basic_runtime_fixed64_init (MIR_context_t ctx) {
+  MIR_type_t blk = MIR_T_BLK;
+  MIR_type_t i64 = MIR_T_I64;
+  MIR_var_t res_arg;
+  res_arg.name = "res";
+  res_arg.type = MIR_T_RBLK;
+  res_arg.size = sizeof (basic_num_t);
+  MIR_var_t bin_vars[3];
+  bin_vars[0] = res_arg;
+  bin_vars[1].name = "a";
+  bin_vars[1].type = MIR_T_BLK;
+  bin_vars[1].size = sizeof (basic_num_t);
+  bin_vars[2].name = "b";
+  bin_vars[2].type = MIR_T_BLK;
+  bin_vars[2].size = sizeof (basic_num_t);
+  fixed64_add_proto = MIR_new_proto_arr (ctx, "fixed64_add_p", 0, NULL, 3, bin_vars);
+  fixed64_add_import = MIR_new_import (ctx, "fixed64_add");
+  fixed64_sub_proto = MIR_new_proto_arr (ctx, "fixed64_sub_p", 0, NULL, 3, bin_vars);
+  fixed64_sub_import = MIR_new_import (ctx, "fixed64_sub");
+  fixed64_mul_proto = MIR_new_proto_arr (ctx, "fixed64_mul_p", 0, NULL, 3, bin_vars);
+  fixed64_mul_import = MIR_new_import (ctx, "fixed64_mul");
+  fixed64_div_proto = MIR_new_proto_arr (ctx, "fixed64_div_p", 0, NULL, 3, bin_vars);
+  fixed64_div_import = MIR_new_import (ctx, "fixed64_div");
+  MIR_var_t un_vars[2];
+  un_vars[0] = res_arg;
+  un_vars[1].name = "a";
+  un_vars[1].type = MIR_T_BLK;
+  un_vars[1].size = sizeof (basic_num_t);
+  fixed64_neg_proto = MIR_new_proto_arr (ctx, "fixed64_neg_p", 0, NULL, 2, un_vars);
+  fixed64_neg_import = MIR_new_import (ctx, "fixed64_neg");
+  MIR_var_t cmp_vars[2];
+  cmp_vars[0].name = "a";
+  cmp_vars[0].type = MIR_T_BLK;
+  cmp_vars[0].size = sizeof (basic_num_t);
+  cmp_vars[1].name = "b";
+  cmp_vars[1].type = MIR_T_BLK;
+  cmp_vars[1].size = sizeof (basic_num_t);
+  fixed64_eq_proto = MIR_new_proto_arr (ctx, "fixed64_eq_p", 1, &i64, 2, cmp_vars);
+  fixed64_eq_import = MIR_new_import (ctx, "fixed64_eq");
+  fixed64_ne_proto = MIR_new_proto_arr (ctx, "fixed64_ne_p", 1, &i64, 2, cmp_vars);
+  fixed64_ne_import = MIR_new_import (ctx, "fixed64_ne");
+  fixed64_lt_proto = MIR_new_proto_arr (ctx, "fixed64_lt_p", 1, &i64, 2, cmp_vars);
+  fixed64_lt_import = MIR_new_import (ctx, "fixed64_lt");
+  fixed64_le_proto = MIR_new_proto_arr (ctx, "fixed64_le_p", 1, &i64, 2, cmp_vars);
+  fixed64_le_import = MIR_new_import (ctx, "fixed64_le");
+  fixed64_gt_proto = MIR_new_proto_arr (ctx, "fixed64_gt_p", 1, &i64, 2, cmp_vars);
+  fixed64_gt_import = MIR_new_import (ctx, "fixed64_gt");
+  fixed64_ge_proto = MIR_new_proto_arr (ctx, "fixed64_ge_p", 1, &i64, 2, cmp_vars);
+  fixed64_ge_import = MIR_new_import (ctx, "fixed64_ge");
+  MIR_var_t int_vars[2];
+  int_vars[0] = res_arg;
+  int_vars[1].name = "i";
+  int_vars[1].type = MIR_T_I64;
+  fixed64_from_int_proto = MIR_new_proto_arr (ctx, "fixed64_from_int_p", 0, NULL, 2, int_vars);
+  fixed64_from_int_import = MIR_new_import (ctx, "fixed64_from_int");
+  MIR_var_t to_int_vars[1];
+  to_int_vars[0].name = "a";
+  to_int_vars[0].type = MIR_T_BLK;
+  to_int_vars[0].size = sizeof (basic_num_t);
+  fixed64_to_int_proto = MIR_new_proto_arr (ctx, "fixed64_to_int_p", 1, &i64, 1, to_int_vars);
+  fixed64_to_int_import = MIR_new_import (ctx, "fixed64_to_int");
+}
+
+int basic_mir_emit_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t *ops,
+                            size_t nops) {
+  MIR_insn_t insn;
+  switch (code) {
+  case MIR_DADD:
+  case MIR_DSUB:
+  case MIR_DMUL:
+  case MIR_DDIV:
+  case MIR_DEQ:
+  case MIR_DNE:
+  case MIR_DLT:
+  case MIR_DLE:
+  case MIR_DGT:
+  case MIR_DGE: insn = basic_mir_binop (ctx, func, code, ops[0], ops[1], ops[2]); break;
+  case MIR_DNEG: insn = basic_mir_unop (ctx, func, code, ops[0], ops[1]); break;
+  case MIR_I2D: insn = basic_mir_i2n (ctx, func, ops[0], ops[1]); break;
+  case MIR_D2I: insn = basic_mir_n2i (ctx, func, ops[0], ops[1]); break;
+  case MIR_DBEQ:
+  case MIR_DBNE:
+  case MIR_DBLT:
+  case MIR_DBLE:
+  case MIR_DBGT:
+  case MIR_DBGE: basic_mir_bcmp (ctx, func, code, ops[0], ops[1], ops[2]); return 1;
+  default: return 0;
+  }
+  MIR_append_insn (ctx, func, insn);
+  return 1;
+}
+
+void basic_input (basic_num_t *res) {
+  if (!basic_num_scan (stdin, res)) *res = BASIC_ZERO;
+}
+
+void basic_pos (basic_num_t *res) { *res = basic_num_from_int (basic_pos_val); }
+
+void basic_input_hash (basic_num_t *res, basic_num_t n) {
+  int idx = basic_num_to_int (n);
+  if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
+    *res = BASIC_ZERO;
+    return;
+  }
+  if (!basic_num_scan (basic_files[idx], res)) *res = BASIC_ZERO;
+}
+
+void basic_read (basic_num_t *res) {
+  if (basic_data_pos >= basic_data_len || basic_data_items[basic_data_pos].is_str) {
+    *res = BASIC_ZERO;
+    return;
+  }
+  *res = basic_data_items[basic_data_pos++].num;
+}
+
+#if defined(BASIC_PRNG128)
+void basic_rnd (basic_num_t *res, basic_num_t n) {
+  if (!seeded) {
+    basic_randomize (BASIC_ZERO, BASIC_ZERO);
+  }
+  __uint128_t r = basic_next_u128 ();
+  uint64_t hi = (uint64_t) (r >> 64);
+  uint64_t lo = (uint64_t) r;
+  basic_num_t base = basic_num_from_int ((long) (1ULL << 32));
+  basic_num_t base64 = basic_num_mul (base, base);
+  basic_num_t hi_num = basic_num_add (basic_num_mul (basic_num_from_int ((long) (hi >> 32)), base),
+                                      basic_num_from_int ((long) (hi & UINT32_MAX)));
+  basic_num_t lo_num = basic_num_add (basic_num_mul (basic_num_from_int ((long) (lo >> 32)), base),
+                                      basic_num_from_int ((long) (lo & UINT32_MAX)));
+  basic_num_t frac = basic_num_div (hi_num, base64);
+  basic_num_t base128 = basic_num_mul (base64, base64);
+  frac = basic_num_add (frac, basic_num_div (lo_num, base128));
+  *res = basic_num_mul (frac, n);
+}
+#else
+void basic_rnd (basic_num_t *res, basic_num_t n) {
+  if (!seeded) {
+    basic_randomize (BASIC_ZERO, BASIC_ZERO);
+  }
+  uint64_t r = basic_next_u64 ();
+  basic_num_t hi = basic_num_from_int ((long) (r >> 32));
+  basic_num_t lo = basic_num_from_int ((long) (r & UINT32_MAX));
+  basic_num_t base = basic_num_from_int ((long) (1ULL << 32));
+  basic_num_t frac = basic_num_add (hi, basic_num_div (lo, base));
+  frac = basic_num_div (frac, base);
+  *res = basic_num_mul (frac, n);
+}
+#endif

--- a/basic/src/basic_runtime_fixed64.h
+++ b/basic/src/basic_runtime_fixed64.h
@@ -1,0 +1,37 @@
+#ifndef BASIC_RUNTIME_FIXED64_H
+#define BASIC_RUNTIME_FIXED64_H
+
+#include "basic_num.h"
+#include "mir.h"
+#include "basic_pool.h"
+
+#ifdef BASIC_USE_FIXED64
+
+#define BASIC_MIR_NUM_T MIR_T_BLK
+static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
+  basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
+  *p = v;
+  MIR_item_t data_item = MIR_new_data (ctx, NULL, MIR_T_U8, sizeof (basic_num_t), p);
+  return MIR_new_ref_op (ctx, data_item);
+}
+
+void basic_runtime_fixed64_init (MIR_context_t ctx);
+int basic_mir_emit_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t *ops,
+                            size_t nops);
+
+#else
+
+static inline void basic_runtime_fixed64_init (MIR_context_t ctx) { (void) ctx; }
+static inline int basic_mir_emit_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
+                                          MIR_op_t *ops, size_t nops) {
+  (void) ctx;
+  (void) func;
+  (void) code;
+  (void) ops;
+  (void) nops;
+  return 0;
+}
+
+#endif
+
+#endif /* BASIC_RUNTIME_FIXED64_H */


### PR DESCRIPTION
## Summary
- extract fixed64-specific runtime helpers into new `basic_runtime_fixed64.c`
- reference new fixed64 runtime from `basic_runtime.c` and build rules

## Testing
- `basic/tests/run-tests.sh basic/basicc`

------
https://chatgpt.com/codex/tasks/task_e_689ef2304b5883269385f33a1daced3b