### PR TITLE
Enable basicc-ld tests in basic-test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -551,8 +551,6 @@ basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUI
 run-basic-tests:
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
-run-basic-tests:
-	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out


### PR DESCRIPTION
## Summary
- ensure `make basic-test` runs `.bas` tests against `basicc-ld` in addition to `basicc`

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689f4f697bd88326a50a91caf235ca06