### PR TITLE
Use var mem ops for fixed64 BASIC operands

### DIFF
--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -101,7 +101,7 @@ static MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_
     r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
     MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
   }
-  return MIR_new_mem_op (ctx, t, sizeof (basic_num_t), r, 0, 1);
+  return _MIR_new_var_mem_op (ctx, t, sizeof (basic_num_t), r, MIR_NON_VAR, 1);
 }
 
 static MIR_insn_t basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -74,7 +74,7 @@ static MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_
     r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
     MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
   }
-  return MIR_new_mem_op (ctx, t, sizeof (basic_num_t), r, 0, 1);
+  return _MIR_new_var_mem_op (ctx, t, sizeof (basic_num_t), r, MIR_NON_VAR, 1);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- Allocate basic_mem operands using `_MIR_new_var_mem_op` with explicit block size
- Ensure fixed64 BASIC operations use block (`MIR_T_BLK`) and rblock (`MIR_T_RBLK`) types

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_689f52386190832698427ec6c41f7ed8