### PR TITLE
Handle fixed64 move instructions

### DIFF
--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -336,6 +336,23 @@ void basic_runtime_fixed64_init (MIR_context_t ctx) {
 int basic_mir_emit_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t *ops,
                             size_t nops) {
   switch (code) {
+  case MIR_DMOV:
+  case MIR_MOV:
+    if ((ops[0].mode == MIR_OP_REG && MIR_reg_type (ctx, ops[0].u.reg, func->u.func) != MIR_T_BLK)
+        || (ops[1].mode == MIR_OP_REG
+            && MIR_reg_type (ctx, ops[1].u.reg, func->u.func) != MIR_T_BLK))
+      return 0;
+    MIR_op_t dst_mem = basic_mem (ctx, func, ops[0], MIR_T_BLK);
+    MIR_op_t src_mem = basic_mem (ctx, func, ops[1], MIR_T_BLK);
+    MIR_append_insn (ctx, func,
+                     MIR_new_insn (ctx, MIR_MOV,
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 0, src_mem.u.mem.base, 0, 1)));
+    MIR_append_insn (ctx, func,
+                     MIR_new_insn (ctx, MIR_MOV,
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 8, src_mem.u.mem.base, 0, 1)));
+    return 1;
   case MIR_DADD:
   case MIR_DSUB:
   case MIR_DMUL:

--- a/basic/test/basic_handle_fixed64_test.c
+++ b/basic/test/basic_handle_fixed64_test.c
@@ -25,9 +25,11 @@ int main (void) {
   basic_mir_emitlbl (func, lbl);
   basic_mir_emit (func, "DMOV", r1, basic_num_from_int (2), BASIC_ZERO);
   basic_mir_emit (func, "DMOV", r2, basic_num_from_int (3), BASIC_ZERO);
-  basic_mir_emit (func, "DADD", r3, r1, r2);
-  basic_mir_emit (func, "DNEG", r3, r3, BASIC_ZERO);
-  basic_mir_ret (func, r3);
+  basic_mir_emit (func, "MOV", r3, r1, BASIC_ZERO);
+  basic_mir_emit (func, "DADD", r3, r3, r2);
+  basic_mir_emit (func, "MOV", r1, r3, BASIC_ZERO);
+  basic_mir_emit (func, "DNEG", r1, r1, BASIC_ZERO);
+  basic_mir_ret (func, r1);
   basic_mir_finish (mod);
   basic_num_t res = basic_mir_run (func, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO);
   assert (basic_num_eq (res, basic_num_neg (basic_num_from_int (5))));


### PR DESCRIPTION
## Summary
- copy fixed64 values with MIR_MOV/DMOV by splitting into two 64-bit moves
- test fixed64 MOV handling in BASIC runtime

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_689f7368509083268b78ae1efd9cc828