### PR TITLE
basic: modularize more statement parsers

### DIFF
--- a/basic/test/parse_helpers_test.c
+++ b/basic/test/parse_helpers_test.c
@@ -26,6 +26,28 @@ int main (void) {
   assert (l.stmts.data[0].kind == ST_GOTO);
   assert (l.stmts.data[0].u.target == 10);
 
+  ok = parse_line (&p, "LET A=1", &l);
+  if (!ok) return 1;
+  assert (l.stmts.len == 1);
+  assert (l.stmts.data[0].kind == ST_LET);
+
+  ok = parse_line (&p, "INC A", &l);
+  if (!ok) return 1;
+  assert (l.stmts.len == 1);
+  assert (l.stmts.data[0].kind == ST_INC);
+
+  ok = parse_line (&p, "DEC A", &l);
+  if (!ok) return 1;
+  assert (l.stmts.len == 1);
+  assert (l.stmts.data[0].kind == ST_DEC);
+
+  ok = parse_line (&p, "IF 1 THEN PRINT 1", &l);
+  if (!ok) return 1;
+  assert (l.stmts.len == 1);
+  assert (l.stmts.data[0].kind == ST_IF);
+  assert (l.stmts.data[0].u.iff.then_stmts.len == 1);
+  assert (l.stmts.data[0].u.iff.then_stmts.data[0].kind == ST_PRINT);
+
   basic_pool_destroy ();
   arena_release (&ast_arena);
   return 0;


### PR DESCRIPTION
## Summary
- factor LET, INC, DEC and IF parsing into dedicated helpers
- dispatch statement parsing through a table of per-statement handlers
- expand parse helper tests to cover new statements

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a013a6f12483269f1b2503cc998ae1