### PR TITLE
Use int64 for BASIC string helpers

### DIFF
--- a/basic/src/AGENTS.md
+++ b/basic/src/AGENTS.md
@@ -76,6 +76,8 @@
 
 ## Built-in Functions
 
+Integer operands are represented as 64-bit signed integers (`int64_t`) when invoking runtime helpers.
+
 | Instruction | Description | Operands | Operand Types | Return |
 |---|---|---|---|---|
 | RND | random number | 1 | decimal | decimal |

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -587,16 +587,16 @@ basic_num_t basic_pow (basic_num_t x, basic_num_t y) { return basic_num_pow (x, 
 basic_num_t basic_pi (void) { return basic_num_acos (basic_num_neg (basic_num_from_int (1))); }
 
 /* Allocate a one-character string. Caller must free with basic_free. */
-char *basic_chr (basic_num_t n) {
+char *basic_chr (int64_t n) {
   char *s = basic_alloc_string (1);
-  if (s != NULL) s[0] = (char) basic_num_to_int (n);
+  if (s != NULL) s[0] = (char) n;
   return s;
 }
 
 /* Allocate a UTF-8 string for the given Unicode code point.
    Caller must free with basic_free. */
-char *basic_unichar (basic_num_t n) {
-  uint32_t code = (uint32_t) basic_num_to_int (n);
+char *basic_unichar (int64_t n) {
+  uint32_t code = (uint32_t) n;
   char buf[4];
   size_t len = 0;
   if (code <= 0x7F) {
@@ -625,8 +625,8 @@ char *basic_unichar (basic_num_t n) {
 
 /* Return a string of length N filled with the first character of S.
    Caller must free the result with basic_free. */
-char *basic_string (basic_num_t n, const char *s) {
-  int len = basic_num_to_int (n);
+char *basic_string (int64_t n, const char *s) {
+  int len = (int) n;
   char ch = s != NULL && s[0] != '\0' ? s[0] : '\0';
   char *res = basic_alloc_string ((size_t) len);
   if (res != NULL) {

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -178,9 +178,9 @@ extern void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_mode (basic_num_t);
 
-extern char *basic_chr (basic_num_t);
-extern char *basic_unichar (basic_num_t);
-extern char *basic_string (basic_num_t, const char *);
+extern char *basic_chr (int64_t);
+extern char *basic_unichar (int64_t);
+extern char *basic_string (int64_t, const char *);
 extern char *basic_concat (const char *, const char *);
 extern char *basic_upper (const char *);
 extern char *basic_lower (const char *);
@@ -3945,40 +3945,50 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       MIR_reg_t res = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       if (strcasecmp (n->var, "CHR$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi),
+                                        MIR_new_reg_op (ctx, arg)));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, chr_proto),
                                             MIR_new_ref_op (ctx, chr_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
       } else if (strcasecmp (n->var, "UNICHAR$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi),
+                                        MIR_new_reg_op (ctx, arg)));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, unichar_proto),
                                             MIR_new_ref_op (ctx, unichar_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
       } else if (strcasecmp (n->var, "STRING$") == 0) {
         MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i),
+                                        MIR_new_reg_op (ctx, a1)));
         MIR_reg_t a2 = gen_expr (ctx, func, vars, n->right);
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
                                             MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
                                             MIR_new_reg_op (ctx, a2)));
       } else if (strcasecmp (n->var, "SPC") == 0) {
         MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
         char buf2[32];
         safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
-        MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
         MIR_append_insn (ctx, func,
-                         MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, space),
-                                       MIR_new_str_op (ctx, (MIR_str_t) {2, " "})));
-        MIR_append_insn (ctx, func,
-                         MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
-                                            MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
-                                            MIR_new_reg_op (ctx, space)));
-      } else if (strcasecmp (n->var, "SPACE$") == 0) {
-        MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
-        char buf2[32];
+                         basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i),
+                                        MIR_new_reg_op (ctx, a1)));
         safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
         MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
         MIR_append_insn (ctx, func,
@@ -3987,7 +3997,25 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
                                             MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
+                                            MIR_new_reg_op (ctx, space)));
+      } else if (strcasecmp (n->var, "SPACE$") == 0) {
+        MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i),
+                                        MIR_new_reg_op (ctx, a1)));
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, space),
+                                       MIR_new_str_op (ctx, (MIR_str_t) {2, " "})));
+        MIR_append_insn (ctx, func,
+                         MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
+                                            MIR_new_ref_op (ctx, string_import),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
                                             MIR_new_reg_op (ctx, space)));
       } else if (strcasecmp (n->var, "INPUT$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
@@ -6440,12 +6468,11 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   }
   rnd_proto = MIR_new_proto (ctx, "basic_rnd_p", 1, &d, 1, BASIC_MIR_NUM_T, "n");
   rnd_import = MIR_new_import (ctx, "basic_rnd");
-  chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, MIR_T_I64, "n");
   chr_import = MIR_new_import (ctx, "basic_chr");
-  unichar_proto = MIR_new_proto (ctx, "basic_unichar_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  unichar_proto = MIR_new_proto (ctx, "basic_unichar_p", 1, &p, 1, MIR_T_I64, "n");
   unichar_import = MIR_new_import (ctx, "basic_unichar");
-  string_proto
-    = MIR_new_proto (ctx, "basic_string_p", 1, &p, 2, BASIC_MIR_NUM_T, "n", MIR_T_P, "s");
+  string_proto = MIR_new_proto (ctx, "basic_string_p", 1, &p, 2, MIR_T_I64, "n", MIR_T_P, "s");
   string_import = MIR_new_import (ctx, "basic_string");
   concat_proto = MIR_new_proto (ctx, "basic_concat_p", 1, &p, 2, MIR_T_P, "a", MIR_T_P, "b");
   concat_import = MIR_new_import (ctx, "basic_concat");

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -374,9 +374,9 @@ extern void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_mode (basic_num_t);
 
-extern char *basic_chr (basic_num_t);
-extern char *basic_unichar (basic_num_t);
-extern char *basic_string (basic_num_t, const char *);
+extern char *basic_chr (int64_t);
+extern char *basic_unichar (int64_t);
+extern char *basic_string (int64_t, const char *);
 extern char *basic_concat (const char *, const char *);
 extern char *basic_upper (const char *);
 extern char *basic_lower (const char *);
@@ -3805,40 +3805,42 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       MIR_reg_t res = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
       if (strcasecmp (n->var, "CHR$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi), MIR_new_reg_op (ctx, arg));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, chr_proto),
                                             MIR_new_ref_op (ctx, chr_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
       } else if (strcasecmp (n->var, "UNICHAR$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi), MIR_new_reg_op (ctx, arg));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, unichar_proto),
                                             MIR_new_ref_op (ctx, unichar_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
       } else if (strcasecmp (n->var, "STRING$") == 0) {
         MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i), MIR_new_reg_op (ctx, a1));
         MIR_reg_t a2 = gen_expr (ctx, func, vars, n->right);
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
                                             MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
                                             MIR_new_reg_op (ctx, a2)));
       } else if (strcasecmp (n->var, "SPC") == 0) {
         MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
         char buf2[32];
         safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
-        MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
-        MIR_append_insn (ctx, func,
-                         MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, space),
-                                       MIR_new_str_op (ctx, (MIR_str_t) {2, " "})));
-        MIR_append_insn (ctx, func,
-                         MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
-                                            MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
-                                            MIR_new_reg_op (ctx, space)));
-      } else if (strcasecmp (n->var, "SPACE$") == 0) {
-        MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
-        char buf2[32];
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i), MIR_new_reg_op (ctx, a1));
         safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
         MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
         MIR_append_insn (ctx, func,
@@ -3847,7 +3849,23 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
                                             MIR_new_ref_op (ctx, string_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
+                                            MIR_new_reg_op (ctx, space)));
+      } else if (strcasecmp (n->var, "SPACE$") == 0) {
+        MIR_reg_t a1 = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t a1i = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, a1i), MIR_new_reg_op (ctx, a1));
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t space = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        MIR_append_insn (ctx, func,
+                         MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, space),
+                                       MIR_new_str_op (ctx, (MIR_str_t) {2, " "})));
+        MIR_append_insn (ctx, func,
+                         MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, string_proto),
+                                            MIR_new_ref_op (ctx, string_import),
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, a1i),
                                             MIR_new_reg_op (ctx, space)));
       } else if (strcasecmp (n->var, "INPUT$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
@@ -6495,12 +6513,11 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   rnd_proto = MIR_new_proto (ctx, "basic_rnd_p", 1, &d, 1, BASIC_MIR_NUM_T, "n");
 #endif
   rnd_import = MIR_new_import (ctx, "basic_rnd");
-  chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, MIR_T_I64, "n");
   chr_import = MIR_new_import (ctx, "basic_chr");
-  unichar_proto = MIR_new_proto (ctx, "basic_unichar_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  unichar_proto = MIR_new_proto (ctx, "basic_unichar_p", 1, &p, 1, MIR_T_I64, "n");
   unichar_import = MIR_new_import (ctx, "basic_unichar");
-  string_proto
-    = MIR_new_proto (ctx, "basic_string_p", 1, &p, 2, BASIC_MIR_NUM_T, "n", MIR_T_P, "s");
+  string_proto = MIR_new_proto (ctx, "basic_string_p", 1, &p, 2, MIR_T_I64, "n", MIR_T_P, "s");
   string_import = MIR_new_import (ctx, "basic_string");
   concat_proto = MIR_new_proto (ctx, "basic_concat_p", 1, &p, 2, MIR_T_P, "a", MIR_T_P, "b");
   concat_import = MIR_new_import (ctx, "basic_concat");

--- a/basic/test/basic_runtime_lowmem_test.c
+++ b/basic/test/basic_runtime_lowmem_test.c
@@ -2,15 +2,16 @@
 #include "basic_runtime.h"
 #include <stdio.h>
 #include <sys/resource.h>
+#include <stdint.h>
 
-char *basic_string (basic_num_t n, const char *s);
+char *basic_string (int64_t n, const char *s);
 
 /* Test runtime helpers under low-memory conditions. */
 int main (void) {
   struct rlimit lim = {32 * 1024 * 1024, 32 * 1024 * 1024};
   setrlimit (RLIMIT_AS, &lim);
 
-  char *s = basic_string (basic_num_from_int (40 * 1024 * 1024), "A");
+  char *s = basic_string (40 * 1024 * 1024, "A");
   if (s != NULL) return 1;
 
   void *arr = basic_dim_alloc (NULL, basic_num_from_int (40 * 1024 * 1024), BASIC_ZERO);


### PR DESCRIPTION
## Summary
- pass `int64_t` to `basic_chr`, `basic_unichar`, and `basic_string`
- convert numeric expressions to 64-bit integers before string helper calls
- document integer parameters for runtime helpers

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_68a0362608008326be000eba5d0bb9a5