### PR TITLE
Use int64 file handles for BASIC I/O

### DIFF
--- a/basic/src/AGENTS.md
+++ b/basic/src/AGENTS.md
@@ -74,6 +74,9 @@
 | CALL | call machine code | 1 | integer | none |
 | EVAL | evaluate expression | 1 | string | none |
 
+File handles for `OPEN`, `CLOSE`, and `#` I/O variants (`PRINT#`, `INPUT#`, `GET#`, `PUT#`) are
+passed as 64-bit integers.
+
 ## Built-in Functions
 
 | Instruction | Description | Operands | Operand Types | Return |

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -359,8 +359,8 @@ int basic_strcmp (const char *a, const char *b) {
 #define BASIC_MAX_FILES 16
 FILE *basic_files[BASIC_MAX_FILES];
 
-void basic_open (basic_num_t n, const char *path) {
-  int idx = basic_num_to_int (n);
+void basic_open (int64_t n, const char *path) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES) return;
   if (basic_files[idx] != NULL) {
     fclose (basic_files[idx]);
@@ -371,8 +371,8 @@ void basic_open (basic_num_t n, const char *path) {
   basic_files[idx] = f;
 }
 
-void basic_close (basic_num_t n) {
-  int idx = basic_num_to_int (n);
+void basic_close (int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES) return;
   if (basic_files[idx] != NULL) {
     fclose (basic_files[idx]);
@@ -380,24 +380,24 @@ void basic_close (basic_num_t n) {
   }
 }
 
-void basic_print_hash (basic_num_t n, basic_num_t x) {
-  int idx = basic_num_to_int (n);
+void basic_print_hash (int64_t n, basic_num_t x) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return;
   char buf[128];
   basic_num_to_chars (x, buf, sizeof (buf));
   fputs (buf, basic_files[idx]);
 }
 
-void basic_print_hash_str (basic_num_t n, const char *s) {
-  int idx = basic_num_to_int (n);
+void basic_print_hash_str (int64_t n, const char *s) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return;
   fputs (s, basic_files[idx]);
 }
 
 /* Read a line from an open file and return a newly allocated string.
    Caller must free the result with basic_free. */
-char *basic_input_hash_str (basic_num_t n) {
-  int idx = basic_num_to_int (n);
+char *basic_input_hash_str (int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
     char *res = basic_alloc_string (0);
     if (res == NULL) return NULL;
@@ -421,8 +421,8 @@ char *basic_input_hash_str (basic_num_t n) {
 
 /* Read a single character from an open file and return it as a
    newly allocated string. Caller must free the result with basic_free. */
-char *basic_get_hash (basic_num_t n) {
-  int idx = basic_num_to_int (n);
+char *basic_get_hash (int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
     char *s = basic_alloc_string (1);
     if (s != NULL) s[0] = 0;
@@ -435,15 +435,15 @@ char *basic_get_hash (basic_num_t n) {
   return s;
 }
 
-void basic_put_hash (basic_num_t n, const char *s) {
-  int idx = basic_num_to_int (n);
+void basic_put_hash (int64_t n, const char *s) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return;
   int c = s != NULL && s[0] != '\0' ? (unsigned char) s[0] : 0;
   fputc (c, basic_files[idx]);
 }
 
-basic_num_t basic_eof (basic_num_t n) {
-  int idx = basic_num_to_int (n);
+basic_num_t basic_eof (int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return basic_num_from_int (-1);
   return feof (basic_files[idx]) ? basic_num_from_int (-1) : BASIC_ZERO;
 }

--- a/basic/src/basic_runtime_double.c
+++ b/basic/src/basic_runtime_double.c
@@ -60,8 +60,8 @@ basic_num_t basic_input (void) {
 
 basic_num_t basic_pos (void) { return basic_num_from_int (basic_pos_val); }
 
-basic_num_t basic_input_hash (basic_num_t n) {
-  int idx = basic_num_to_int (n);
+basic_num_t basic_input_hash (int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return BASIC_ZERO;
   basic_num_t x = BASIC_ZERO;
   if (!basic_num_scan (basic_files[idx], &x)) return BASIC_ZERO;

--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -383,8 +383,8 @@ void basic_input (basic_num_t *res) {
 
 void basic_pos (basic_num_t *res) { *res = basic_num_from_int (basic_pos_val); }
 
-void basic_input_hash (basic_num_t *res, basic_num_t n) {
-  int idx = basic_num_to_int (n);
+void basic_input_hash (basic_num_t *res, int64_t n) {
+  int idx = (int) n;
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) {
     *res = BASIC_ZERO;
     return;

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -418,19 +418,19 @@ extern char *basic_input_chr (basic_num_t);
 extern basic_num_t basic_peek (basic_num_t);
 extern void basic_poke (basic_num_t, basic_num_t);
 
-extern void basic_open (basic_num_t, const char *);
-extern void basic_close (basic_num_t);
-extern void basic_print_hash (basic_num_t, basic_num_t);
-extern void basic_print_hash_str (basic_num_t, const char *);
+extern void basic_open (int64_t, const char *);
+extern void basic_close (int64_t);
+extern void basic_print_hash (int64_t, basic_num_t);
+extern void basic_print_hash_str (int64_t, const char *);
 #if defined(BASIC_USE_FIXED64)
-extern void basic_input_hash (basic_num_t *, basic_num_t);
+extern void basic_input_hash (basic_num_t *, int64_t);
 #else
-extern basic_num_t basic_input_hash (basic_num_t);
+extern basic_num_t basic_input_hash (int64_t);
 #endif
-extern char *basic_input_hash_str (basic_num_t);
-extern char *basic_get_hash (basic_num_t);
-extern void basic_put_hash (basic_num_t, const char *);
-extern basic_num_t basic_eof (basic_num_t);
+extern char *basic_input_hash_str (int64_t);
+extern char *basic_get_hash (int64_t);
+extern void basic_put_hash (int64_t, const char *);
+extern basic_num_t basic_eof (int64_t);
 
 #if defined(BASIC_USE_FIXED64)
 extern basic_num_t fixed64_add (basic_num_t, basic_num_t);
@@ -3653,6 +3653,28 @@ static void call_runtime_unary (MIR_context_t ctx, MIR_item_t func, MIR_item_t p
                                  MIR_new_reg_op (ctx, hi)));
 }
 
+static void call_runtime_unary_i64 (MIR_context_t ctx, MIR_item_t func, MIR_item_t proto,
+                                    MIR_item_t import, MIR_reg_t res, MIR_reg_t arg) {
+  char buf[32];
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto),
+                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, lo),
+                                      MIR_new_reg_op (ctx, hi), MIR_new_reg_op (ctx, arg)));
+  MIR_op_t res_mem = basic_mem (ctx, func, MIR_new_reg_op (ctx, res), MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 0, res_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, lo)));
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 8, res_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, hi)));
+}
+
 static void call_runtime_binary (MIR_context_t ctx, MIR_item_t func, MIR_item_t proto,
                                  MIR_item_t import, MIR_reg_t res, MIR_reg_t arg1, MIR_reg_t arg2) {
   MIR_op_t arg1_mem = basic_mem (ctx, func, MIR_new_reg_op (ctx, arg1), MIR_T_BLK);
@@ -4123,10 +4145,15 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
                                           MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
     } else if (strcasecmp (n->var, "EOF") == 0) {
       MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+      char buf[32];
+      safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+      MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+      basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi),
+                     MIR_new_reg_op (ctx, arg));
       MIR_append_insn (ctx, func,
                        MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, eof_proto),
                                           MIR_new_ref_op (ctx, eof_import),
-                                          MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                          MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
     } else if (strcasecmp (n->var, "ABS") == 0) {
       MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
       call_runtime_unary (ctx, func, abs_proto, abs_import, res, arg);
@@ -4725,10 +4752,15 @@ static void gen_print (Stmt *s) {
 
 static void gen_print_hash (Stmt *s) {
   MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.printhash.num);
+  char buf[32];
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                 MIR_new_reg_op (g_ctx, fn));
   for (size_t k = 0; k < s->u.printhash.n; k++)
-    print_hash_item (fn, s->u.printhash.items[k],
+    print_hash_item (fni, s->u.printhash.items[k],
                      k + 1 < s->u.printhash.n ? s->u.printhash.items[k + 1] : NULL);
-  if (!s->u.printhash.no_nl) print_hash_str (fn, (MIR_str_t) {2, "\n"});
+  if (!s->u.printhash.no_nl) print_hash_str (fni, (MIR_str_t) {2, "\n"});
 }
 
 static void input_str_var (MIR_reg_t v) {
@@ -4837,7 +4869,7 @@ static void input_hash_str (MIR_reg_t v, MIR_reg_t fn) {
 
 static void input_hash_num (MIR_reg_t v, MIR_reg_t fn) {
 #if defined(BASIC_USE_FIXED64)
-  call_runtime_unary (g_ctx, g_func, input_hash_proto, input_hash_import, v, fn);
+  call_runtime_unary_i64 (g_ctx, g_func, input_hash_proto, input_hash_import, v, fn);
 #else
   call2 (input_hash_proto, input_hash_import, MIR_new_reg_op (g_ctx, v),
          MIR_new_reg_op (g_ctx, fn));
@@ -4846,8 +4878,13 @@ static void input_hash_num (MIR_reg_t v, MIR_reg_t fn) {
 
 static void gen_input_hash (Stmt *s) {
   MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.inputhash.num);
+  char buf[32];
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                 MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t v = get_var (&g_vars, g_ctx, g_func, s->u.inputhash.var);
-  (s->u.inputhash.is_str ? input_hash_str : input_hash_num) (v, fn);
+  (s->u.inputhash.is_str ? input_hash_str : input_hash_num) (v, fni);
 }
 
 static void gen_get (Stmt *s) {
@@ -4857,8 +4894,13 @@ static void gen_get (Stmt *s) {
 
 static void gen_get_hash (Stmt *s) {
   MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.gethash.num);
+  char buf[32];
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                 MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t v = get_var (&g_vars, g_ctx, g_func, s->u.gethash.var);
-  call2 (get_hash_proto, get_hash_import, MIR_new_reg_op (g_ctx, v), MIR_new_reg_op (g_ctx, fn));
+  call2 (get_hash_proto, get_hash_import, MIR_new_reg_op (g_ctx, v), MIR_new_reg_op (g_ctx, fni));
 }
 
 static void gen_put (Stmt *s) {
@@ -4868,8 +4910,13 @@ static void gen_put (Stmt *s) {
 
 static void gen_put_hash (Stmt *s) {
   MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.puthash.num);
+  char buf[32];
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                 MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t r = gen_expr (g_ctx, g_func, &g_vars, s->u.puthash.expr);
-  call2 (put_hash_proto, put_hash_import, MIR_new_reg_op (g_ctx, fn), MIR_new_reg_op (g_ctx, r));
+  call2 (put_hash_proto, put_hash_import, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, r));
 }
 
 static void gen_poke (Stmt *s) {
@@ -5242,19 +5289,29 @@ static void gen_stmt (Stmt *s) {
   }
   case ST_OPEN: {
     MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.open.num);
+    char buf[32];
+    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+    MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                   MIR_new_reg_op (g_ctx, fn));
     MIR_reg_t path = gen_expr (g_ctx, g_func, &g_vars, s->u.open.path);
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 4, MIR_new_ref_op (g_ctx, open_proto),
                                         MIR_new_ref_op (g_ctx, open_import),
-                                        MIR_new_reg_op (g_ctx, fn), MIR_new_reg_op (g_ctx, path)));
+                                        MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, path)));
     break;
   }
   case ST_CLOSE: {
     MIR_reg_t fn = gen_expr (g_ctx, g_func, &g_vars, s->u.close.num);
+    char buf[32];
+    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+    MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
+    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
+                   MIR_new_reg_op (g_ctx, fn));
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, close_proto),
                                         MIR_new_ref_op (g_ctx, close_import),
-                                        MIR_new_reg_op (g_ctx, fn)));
+                                        MIR_new_reg_op (g_ctx, fni)));
     break;
   }
   case ST_TEXT: {
@@ -6343,34 +6400,31 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   fixed64_to_int_proto = MIR_new_proto_arr (ctx, "fixed64_to_int_p", 1, &i64_, 1, to_int_vars);
   fixed64_to_int_import = MIR_new_import (ctx, "fixed64_to_int");
 #endif
-  open_proto
-    = MIR_new_proto (ctx, "basic_open_p", 0, NULL, 2, BASIC_MIR_NUM_T, "n", MIR_T_P, "path");
+  open_proto = MIR_new_proto (ctx, "basic_open_p", 0, NULL, 2, MIR_T_I64, "n", MIR_T_P, "path");
   open_import = MIR_new_import (ctx, "basic_open");
-  close_proto = MIR_new_proto (ctx, "basic_close_p", 0, NULL, 1, BASIC_MIR_NUM_T, "n");
+  close_proto = MIR_new_proto (ctx, "basic_close_p", 0, NULL, 1, MIR_T_I64, "n");
   close_import = MIR_new_import (ctx, "basic_close");
-  printh_proto = MIR_new_proto (ctx, "basic_print_hash_p", 0, NULL, 2, BASIC_MIR_NUM_T, "n",
-                                BASIC_MIR_NUM_T, "x");
+  printh_proto
+    = MIR_new_proto (ctx, "basic_print_hash_p", 0, NULL, 2, MIR_T_I64, "n", BASIC_MIR_NUM_T, "x");
   printh_import = MIR_new_import (ctx, "basic_print_hash");
   prinths_proto
-    = MIR_new_proto (ctx, "basic_print_hash_str_p", 0, NULL, 2, BASIC_MIR_NUM_T, "n", MIR_T_P, "s");
+    = MIR_new_proto (ctx, "basic_print_hash_str_p", 0, NULL, 2, MIR_T_I64, "n", MIR_T_P, "s");
   prinths_import = MIR_new_import (ctx, "basic_print_hash_str");
 #if defined(BASIC_USE_FIXED64)
   MIR_var_t hash_arg;
   hash_arg.name = "n";
-  hash_arg.type = MIR_T_BLK;
-  hash_arg.size = sizeof (basic_num_t);
+  hash_arg.type = MIR_T_I64;
   input_hash_proto = MIR_new_proto_arr (ctx, "basic_input_hash_p", 2, i64_pair, 1, &hash_arg);
 #else
-  input_hash_proto = MIR_new_proto (ctx, "basic_input_hash_p", 1, &d, 1, BASIC_MIR_NUM_T, "n");
+  input_hash_proto = MIR_new_proto (ctx, "basic_input_hash_p", 1, &d, 1, MIR_T_I64, "n");
 #endif
   input_hash_import = MIR_new_import (ctx, "basic_input_hash");
-  input_hash_str_proto
-    = MIR_new_proto (ctx, "basic_input_hash_str_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  input_hash_str_proto = MIR_new_proto (ctx, "basic_input_hash_str_p", 1, &p, 1, MIR_T_I64, "n");
   input_hash_str_import = MIR_new_import (ctx, "basic_input_hash_str");
-  get_hash_proto = MIR_new_proto (ctx, "basic_get_hash_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
+  get_hash_proto = MIR_new_proto (ctx, "basic_get_hash_p", 1, &p, 1, MIR_T_I64, "n");
   get_hash_import = MIR_new_import (ctx, "basic_get_hash");
   put_hash_proto
-    = MIR_new_proto (ctx, "basic_put_hash_p", 0, NULL, 2, BASIC_MIR_NUM_T, "n", MIR_T_P, "s");
+    = MIR_new_proto (ctx, "basic_put_hash_p", 0, NULL, 2, MIR_T_I64, "n", MIR_T_P, "s");
   put_hash_import = MIR_new_import (ctx, "basic_put_hash");
   home_proto = MIR_new_proto (ctx, "basic_home_p", 0, NULL, 0);
   home_import = MIR_new_import (ctx, "basic_home");
@@ -6518,7 +6572,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   inkey_import = MIR_new_import (ctx, "basic_inkey");
   peek_proto = MIR_new_proto (ctx, "basic_peek_p", 1, &d, 1, BASIC_MIR_NUM_T, "addr");
   peek_import = MIR_new_import (ctx, "basic_peek");
-  eof_proto = MIR_new_proto (ctx, "basic_eof_p", 1, &d, 1, BASIC_MIR_NUM_T, "n");
+  eof_proto = MIR_new_proto (ctx, "basic_eof_p", 1, &d, 1, MIR_T_I64, "n");
   eof_import = MIR_new_import (ctx, "basic_eof");
 #if defined(BASIC_USE_FIXED64)
   pos_proto = MIR_new_proto_arr (ctx, "basic_pos_p", 2, i64_pair, 0, NULL);


### PR DESCRIPTION
## Summary
- pass BASIC file numbers as 64-bit integers through compiler and runtime
- document integer file handles in BASIC agent notes

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a0363940788326a22ff0d22f1b0563