### PR TITLE
Use int64_t for BASIC string helper counts

### DIFF
--- a/basic/src/AGENTS.md
+++ b/basic/src/AGENTS.md
@@ -136,7 +136,7 @@ Integer operands are represented as 64-bit signed integers (`int64_t`) when invo
 | STRING$ | repeat string | 2 | integer, string | string |
 | TIME$ | time as string | 0 |  | string |
 | DATE$ | date as string | 0 |  | string |
-| INPUT$ | input string | 0 |  | string |
+| INPUT$ | input string | 1 | integer | string |
 | SPC | spaces | 1 | integer | string |
 | SPACE$ | spaces | 1 | integer | string |
 | TAB | tab to column | 1 | integer | none |

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -668,13 +668,9 @@ char *basic_lower (const char *s) {
 
 /* Return the leftmost N characters of S as a newly allocated string.
    Caller must free the result with basic_free. */
-char *basic_left (const char *s, basic_num_t n) {
+char *basic_left (const char *s, int64_t n) {
   size_t len = s != NULL ? strlen (s) : 0;
-  size_t cnt = 0;
-  if (!basic_num_lt (n, BASIC_ZERO)) {
-    long n_int = basic_num_to_int (n);
-    if (n_int > 0) cnt = (size_t) n_int;
-  }
+  size_t cnt = n > 0 ? (size_t) n : 0;
   if (cnt > len) cnt = len;
   char *res = basic_alloc_string (cnt);
   if (res != NULL) memcpy (res, s, cnt);
@@ -683,36 +679,31 @@ char *basic_left (const char *s, basic_num_t n) {
 
 /* Return the rightmost N characters of S as a newly allocated string.
    Caller must free the result with basic_free. */
-char *basic_right (const char *s, basic_num_t n) {
+char *basic_right (const char *s, int64_t n) {
   size_t len = s != NULL ? strlen (s) : 0;
-  size_t cnt = 0;
-  if (!basic_num_lt (n, BASIC_ZERO)) {
-    long n_int = basic_num_to_int (n);
-    if (n_int > 0) cnt = (size_t) n_int;
-  }
+  size_t cnt = n > 0 ? (size_t) n : 0;
   if (cnt > len) cnt = len;
   char *res = basic_alloc_string (cnt);
   if (res != NULL) memcpy (res, s + len - cnt, cnt);
   return res;
 }
 
-/* Return a substring of S starting at START_D with length LEN_D.
+/* Return a substring of S starting at START with length LEN.
    Caller must free the result with basic_free. */
-char *basic_mid (const char *s, basic_num_t start_d, basic_num_t len_d) {
+char *basic_mid (const char *s, int64_t start, int64_t len_d) {
   size_t len = s != NULL ? strlen (s) : 0;
-  long start_i = basic_num_to_int (start_d);
-  if (basic_num_lt (start_d, basic_num_from_int (1))) start_i = 1;
-  size_t start = (size_t) start_i;
-  start--;
-  if (start >= len) {
+  long start_i = start < 1 ? 1 : start;
+  size_t start_pos = (size_t) start_i;
+  start_pos--;
+  if (start_pos >= len) {
     char *res = basic_alloc_string (0);
     if (res == NULL) return NULL;
     return res;
   }
-  size_t cnt = basic_num_lt (len_d, BASIC_ZERO) ? len - start : (size_t) basic_num_to_int (len_d);
-  if (start + cnt > len) cnt = len - start;
+  size_t cnt = len_d < 0 ? len - start_pos : (size_t) len_d;
+  if (start_pos + cnt > len) cnt = len - start_pos;
   char *res = basic_alloc_string (cnt);
-  if (res != NULL) memcpy (res, s + start, cnt);
+  if (res != NULL) memcpy (res, s + start_pos, cnt);
   return res;
 }
 
@@ -796,8 +787,8 @@ char *basic_date_str (void) {
 
 /* Read N characters from stdin and return them as a newly allocated string.
    Caller must free the result with basic_free. */
-char *basic_input_chr (basic_num_t n) {
-  int len = basic_num_to_int (n);
+char *basic_input_chr (int64_t n) {
+  int len = (int) n;
   char *res = basic_alloc_string ((size_t) len);
   int i = 0;
   if (res != NULL) {

--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -6,6 +6,15 @@
 #include "basic_runtime_fixed64.h"
 #include "basic_runtime.h"
 #include "basic_num.h"
+
+/* Declarations for common helpers from basic_runtime.c */
+char *basic_chr (int64_t);
+char *basic_unichar (int64_t);
+char *basic_string (int64_t, const char *);
+char *basic_left (const char *, int64_t);
+char *basic_right (const char *, int64_t);
+char *basic_mid (const char *, int64_t, int64_t);
+char *basic_input_chr (int64_t);
 #define BASIC_PRNG128 1
 
 static int seeded = 0;
@@ -433,3 +442,14 @@ void basic_rnd (basic_num_t *res, basic_num_t n) {
   *res = basic_num_mul (frac, n);
 }
 #endif
+
+/* Wrappers to match integer parameter helpers. */
+char *basic_chr_wrap (int64_t n) { return basic_chr (n); }
+char *basic_unichar_wrap (int64_t n) { return basic_unichar (n); }
+char *basic_string_wrap (int64_t n, const char *s) { return basic_string (n, s); }
+char *basic_left_wrap (const char *s, int64_t n) { return basic_left (s, n); }
+char *basic_right_wrap (const char *s, int64_t n) { return basic_right (s, n); }
+char *basic_mid_wrap (const char *s, int64_t start, int64_t len) {
+  return basic_mid (s, start, len);
+}
+char *basic_input_chr_wrap (int64_t n) { return basic_input_chr (n); }

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -343,6 +343,7 @@ extern basic_num_t basic_exp (basic_num_t);
 extern basic_num_t basic_fact (basic_num_t);
 extern basic_num_t basic_pow (basic_num_t, basic_num_t);
 extern basic_num_t basic_pi (void);
+#endif
 
 extern void basic_screen (int64_t);
 extern void basic_cls (void);
@@ -372,15 +373,15 @@ extern void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
 extern void basic_mode (basic_num_t);
 
-extern char *basic_chr (int64_t);
-extern char *basic_unichar (int64_t);
-extern char *basic_string (int64_t, const char *);
+extern char *basic_chr_wrap (int64_t);
+extern char *basic_unichar_wrap (int64_t);
+extern char *basic_string_wrap (int64_t, const char *);
 extern char *basic_concat (const char *, const char *);
 extern char *basic_upper (const char *);
 extern char *basic_lower (const char *);
-extern char *basic_left (const char *, basic_num_t);
-extern char *basic_right (const char *, basic_num_t);
-extern char *basic_mid (const char *, basic_num_t, basic_num_t);
+extern char *basic_left_wrap (const char *, int64_t);
+extern char *basic_right_wrap (const char *, int64_t);
+extern char *basic_mid_wrap (const char *, int64_t, int64_t);
 extern char *basic_mirror (const char *);
 extern long basic_len (const char *);
 extern basic_num_t basic_val (const char *);
@@ -414,7 +415,7 @@ extern basic_num_t basic_int (basic_num_t);
 extern basic_num_t basic_timer (void);
 extern char *basic_time_str (void);
 extern char *basic_date_str (void);
-extern char *basic_input_chr (basic_num_t);
+extern char *basic_input_chr_wrap (int64_t);
 extern basic_num_t basic_peek (basic_num_t);
 extern void basic_poke (int64_t, int64_t);
 
@@ -591,13 +592,13 @@ static void *resolve (const char *name) {
   if (!strcmp (name, "basic_profile_func_enter")) return basic_profile_func_enter;
   if (!strcmp (name, "basic_profile_func_exit")) return basic_profile_func_exit;
 
-  if (!strcmp (name, "basic_chr")) return basic_chr;
-  if (!strcmp (name, "basic_unichar")) return basic_unichar;
-  if (!strcmp (name, "basic_string")) return basic_string;
+  if (!strcmp (name, "basic_chr_wrap")) return basic_chr_wrap;
+  if (!strcmp (name, "basic_unichar_wrap")) return basic_unichar_wrap;
+  if (!strcmp (name, "basic_string_wrap")) return basic_string_wrap;
   if (!strcmp (name, "basic_concat")) return basic_concat;
-  if (!strcmp (name, "basic_left")) return basic_left;
-  if (!strcmp (name, "basic_right")) return basic_right;
-  if (!strcmp (name, "basic_mid")) return basic_mid;
+  if (!strcmp (name, "basic_left_wrap")) return basic_left_wrap;
+  if (!strcmp (name, "basic_right_wrap")) return basic_right_wrap;
+  if (!strcmp (name, "basic_mid_wrap")) return basic_mid_wrap;
   if (!strcmp (name, "basic_mirror")) return basic_mirror;
   if (!strcmp (name, "basic_upper")) return basic_upper;
   if (!strcmp (name, "basic_lower")) return basic_lower;
@@ -609,7 +610,7 @@ static void *resolve (const char *name) {
   if (!strcmp (name, "basic_timer")) return basic_timer;
   if (!strcmp (name, "basic_time_str")) return basic_time_str;
   if (!strcmp (name, "basic_date_str")) return basic_date_str;
-  if (!strcmp (name, "basic_input_chr")) return basic_input_chr;
+  if (!strcmp (name, "basic_input_chr_wrap")) return basic_input_chr_wrap;
   if (!strcmp (name, "basic_peek")) return basic_peek;
   if (!strcmp (name, "basic_poke")) return basic_poke;
   if (!strcmp (name, "basic_stop")) return basic_stop;
@@ -3863,10 +3864,14 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
                                             MIR_new_reg_op (ctx, space)));
       } else if (strcasecmp (n->var, "INPUT$") == 0) {
         MIR_reg_t arg = gen_expr (ctx, func, vars, n->left);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi), MIR_new_reg_op (ctx, arg));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, input_chr_proto),
                                             MIR_new_ref_op (ctx, input_chr_import),
-                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, arg)));
+                                            MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, argi)));
       } else if (strcasecmp (n->var, "INKEY$") == 0) {
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 3, MIR_new_ref_op (ctx, inkey_proto),
@@ -3885,34 +3890,49 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       } else if (strcasecmp (n->var, "LEFT$") == 0) {
         MIR_reg_t s = gen_expr (ctx, func, vars, n->left);
         MIR_reg_t cnt = gen_expr (ctx, func, vars, n->right);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t cnti = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, cnti), MIR_new_reg_op (ctx, cnt));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, left_proto),
                                             MIR_new_ref_op (ctx, left_import),
                                             MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, s),
-                                            MIR_new_reg_op (ctx, cnt)));
+                                            MIR_new_reg_op (ctx, cnti)));
       } else if (strcasecmp (n->var, "RIGHT$") == 0) {
         MIR_reg_t s = gen_expr (ctx, func, vars, n->left);
         MIR_reg_t cnt = gen_expr (ctx, func, vars, n->right);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t cnti = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, cnti), MIR_new_reg_op (ctx, cnt));
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, right_proto),
                                             MIR_new_ref_op (ctx, right_import),
                                             MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, s),
-                                            MIR_new_reg_op (ctx, cnt)));
+                                            MIR_new_reg_op (ctx, cnti)));
       } else if (strcasecmp (n->var, "MID$") == 0) {
         MIR_reg_t s = gen_expr (ctx, func, vars, n->left);
         MIR_reg_t start = gen_expr (ctx, func, vars, n->right);
+        char buf2[32];
+        safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+        MIR_reg_t starti = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+        basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, starti), MIR_new_reg_op (ctx, start));
         MIR_op_t len_op;
         if (n->index != NULL) {
           MIR_reg_t len = gen_expr (ctx, func, vars, n->index);
-          len_op = MIR_new_reg_op (ctx, len);
+          safe_snprintf (buf2, sizeof (buf2), "$t%d", tmp_id++);
+          MIR_reg_t leni = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf2);
+          basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, leni), MIR_new_reg_op (ctx, len));
+          len_op = MIR_new_reg_op (ctx, leni);
         } else {
-          len_op = emit_num_const (ctx, BASIC_FROM_INT (-1));
+          len_op = MIR_new_int_op (ctx, -1);
         }
         MIR_append_insn (ctx, func,
                          MIR_new_call_insn (ctx, 6, MIR_new_ref_op (ctx, mid_proto),
                                             MIR_new_ref_op (ctx, mid_import),
                                             MIR_new_reg_op (ctx, res), MIR_new_reg_op (ctx, s),
-                                            MIR_new_reg_op (ctx, start), len_op));
+                                            MIR_new_reg_op (ctx, starti), len_op));
       } else if (strcasecmp (n->var, "MIRROR$") == 0) {
         MIR_reg_t s = gen_expr (ctx, func, vars, n->left);
         MIR_append_insn (ctx, func,
@@ -6548,11 +6568,11 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
 #endif
   rnd_import = MIR_new_import (ctx, "basic_rnd");
   chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, MIR_T_I64, "n");
-  chr_import = MIR_new_import (ctx, "basic_chr");
+  chr_import = MIR_new_import (ctx, "basic_chr_wrap");
   unichar_proto = MIR_new_proto (ctx, "basic_unichar_p", 1, &p, 1, MIR_T_I64, "n");
-  unichar_import = MIR_new_import (ctx, "basic_unichar");
+  unichar_import = MIR_new_import (ctx, "basic_unichar_wrap");
   string_proto = MIR_new_proto (ctx, "basic_string_p", 1, &p, 2, MIR_T_I64, "n", MIR_T_P, "s");
-  string_import = MIR_new_import (ctx, "basic_string");
+  string_import = MIR_new_import (ctx, "basic_string_wrap");
   concat_proto = MIR_new_proto (ctx, "basic_concat_p", 1, &p, 2, MIR_T_P, "a", MIR_T_P, "b");
   concat_import = MIR_new_import (ctx, "basic_concat");
   int_proto = MIR_new_proto (ctx, "basic_int_p", 1, &d, 1, BASIC_MIR_NUM_T, "x");
@@ -6563,8 +6583,8 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   time_str_import = MIR_new_import (ctx, "basic_time_str");
   date_str_proto = MIR_new_proto (ctx, "basic_date_str_p", 1, &p, 0);
   date_str_import = MIR_new_import (ctx, "basic_date_str");
-  input_chr_proto = MIR_new_proto (ctx, "basic_input_chr_p", 1, &p, 1, BASIC_MIR_NUM_T, "n");
-  input_chr_import = MIR_new_import (ctx, "basic_input_chr");
+  input_chr_proto = MIR_new_proto (ctx, "basic_input_chr_p", 1, &p, 1, MIR_T_I64, "n");
+  input_chr_import = MIR_new_import (ctx, "basic_input_chr_wrap");
   inkey_proto = MIR_new_proto (ctx, "basic_inkey_p", 1, &p, 0);
   inkey_import = MIR_new_import (ctx, "basic_inkey");
   peek_proto = MIR_new_proto (ctx, "basic_peek_p", 1, &d, 1, BASIC_MIR_NUM_T, "addr");
@@ -6633,13 +6653,13 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   pow_import = MIR_new_import (ctx, "basic_pow");
   pi_proto = MIR_new_proto_arr (ctx, "basic_pi_p", 2, i64_pair, 0, NULL);
   pi_import = MIR_new_import (ctx, "basic_pi");
-  left_proto = MIR_new_proto (ctx, "basic_left_p", 1, &p, 2, MIR_T_P, "s", BASIC_MIR_NUM_T, "n");
-  left_import = MIR_new_import (ctx, "basic_left");
-  right_proto = MIR_new_proto (ctx, "basic_right_p", 1, &p, 2, MIR_T_P, "s", BASIC_MIR_NUM_T, "n");
-  right_import = MIR_new_import (ctx, "basic_right");
-  mid_proto = MIR_new_proto (ctx, "basic_mid_p", 1, &p, 3, MIR_T_P, "s", BASIC_MIR_NUM_T, "start",
-                             BASIC_MIR_NUM_T, "len");
-  mid_import = MIR_new_import (ctx, "basic_mid");
+  left_proto = MIR_new_proto (ctx, "basic_left_p", 1, &p, 2, MIR_T_P, "s", MIR_T_I64, "n");
+  left_import = MIR_new_import (ctx, "basic_left_wrap");
+  right_proto = MIR_new_proto (ctx, "basic_right_p", 1, &p, 2, MIR_T_P, "s", MIR_T_I64, "n");
+  right_import = MIR_new_import (ctx, "basic_right_wrap");
+  mid_proto = MIR_new_proto (ctx, "basic_mid_p", 1, &p, 3, MIR_T_P, "s", MIR_T_I64, "start",
+                             MIR_T_I64, "len");
+  mid_import = MIR_new_import (ctx, "basic_mid_wrap");
   mirror_proto = MIR_new_proto (ctx, "basic_mirror_p", 1, &p, 1, MIR_T_P, "s");
   mirror_import = MIR_new_import (ctx, "basic_mirror");
   upper_proto = MIR_new_proto (ctx, "basic_upper_p", 1, &p, 1, MIR_T_P, "s");


### PR DESCRIPTION
## Summary
- represent count and code point parameters as `int64_t` in BASIC string helpers
- add fixed64 wrapper functions and adjust MIR prototypes
- update BASIC AGENTS instructions to note integer argument for `INPUT$`

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a03c8787b883268d5cecf788442b37