### PR TITLE
basic: centralize runtime helper prototypes

### DIFF
--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -23,6 +23,7 @@
 #include "basic_runtime.h"
 #include "basic_pool.h"
 #include "basic_runtime_fixed64.h"
+#include "basic_runtime_shared.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define BASIC_MIR_NUM_T MIR_T_LD
@@ -447,12 +448,6 @@ basic_num_t basic_eof (int64_t n) {
   if (idx < 0 || idx >= BASIC_MAX_FILES || basic_files[idx] == NULL) return basic_num_from_int (-1);
   return feof (basic_files[idx]) ? basic_num_from_int (-1) : BASIC_ZERO;
 }
-
-typedef struct BasicData {
-  int is_str;
-  basic_num_t num;
-  char *str;
-} BasicData;
 
 BasicData *basic_data_items = NULL;
 size_t basic_data_len = 0;

--- a/basic/src/basic_runtime_double.c
+++ b/basic/src/basic_runtime_double.c
@@ -4,19 +4,11 @@
 
 #include "basic_runtime.h"
 #include "basic_num.h"
+#include "basic_runtime_shared.h"
 
 extern int basic_pos_val;
 #define BASIC_MAX_FILES 16
 extern FILE *basic_files[];
-
-typedef struct BasicData {
-  int is_str;
-  basic_num_t num;
-  char *str;
-} BasicData;
-extern BasicData *basic_data_items;
-extern size_t basic_data_len;
-extern size_t basic_data_pos;
 
 static int seeded = 0;
 static uint64_t rng_state = 0;

--- a/basic/src/basic_runtime_fixed64.c
+++ b/basic/src/basic_runtime_fixed64.c
@@ -6,15 +6,9 @@
 #include "basic_runtime_fixed64.h"
 #include "basic_runtime.h"
 #include "basic_num.h"
+#include "basic_runtime_shared.h"
 
-/* Declarations for common helpers from basic_runtime.c */
-char *basic_chr (int64_t);
-char *basic_unichar (int64_t);
-char *basic_string (int64_t, const char *);
-char *basic_left (const char *, int64_t);
-char *basic_right (const char *, int64_t);
-char *basic_mid (const char *, int64_t, int64_t);
-char *basic_input_chr (int64_t);
+/* Declarations moved to basic_runtime_shared.h */
 #define BASIC_PRNG128 1
 
 static int seeded = 0;
@@ -83,14 +77,6 @@ void basic_randomize (basic_num_t n, basic_num_t has_seed) {
 extern int basic_pos_val;
 #define BASIC_MAX_FILES 16
 extern FILE *basic_files[];
-typedef struct BasicData {
-  int is_str;
-  basic_num_t num;
-  char *str;
-} BasicData;
-extern BasicData *basic_data_items;
-extern size_t basic_data_len;
-extern size_t basic_data_pos;
 
 static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
   fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,

--- a/basic/src/basic_runtime_fixed64.h
+++ b/basic/src/basic_runtime_fixed64.h
@@ -4,6 +4,7 @@
 #include "basic_num.h"
 #include "mir.h"
 #include "basic_pool.h"
+#include <stdint.h>
 
 #ifdef BASIC_USE_FIXED64
 
@@ -18,6 +19,20 @@ static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
 void basic_runtime_fixed64_init (MIR_context_t ctx);
 int basic_mir_emit_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t *ops,
                             size_t nops);
+
+void basic_input (basic_num_t *);
+void basic_read (basic_num_t *);
+void basic_pos (basic_num_t *);
+void basic_rnd (basic_num_t *, basic_num_t);
+void basic_input_hash (basic_num_t *, int64_t);
+
+char *basic_chr_wrap (int64_t);
+char *basic_unichar_wrap (int64_t);
+char *basic_string_wrap (int64_t, const char *);
+char *basic_left_wrap (const char *, int64_t);
+char *basic_right_wrap (const char *, int64_t);
+char *basic_mid_wrap (const char *, int64_t, int64_t);
+char *basic_input_chr_wrap (int64_t);
 
 #else
 

--- a/basic/src/basic_runtime_shared.h
+++ b/basic/src/basic_runtime_shared.h
@@ -1,0 +1,144 @@
+#ifndef BASIC_RUNTIME_SHARED_H
+#define BASIC_RUNTIME_SHARED_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "basic_num.h"
+
+void basic_print (basic_num_t);
+void basic_print_str (const char *);
+
+#ifndef BASIC_USE_FIXED64
+basic_num_t basic_input (void);
+basic_num_t basic_read (void);
+basic_num_t basic_rnd (basic_num_t);
+basic_num_t basic_pos (void);
+basic_num_t basic_input_hash (int64_t);
+#endif
+
+char *basic_input_str (void);
+char *basic_get (void);
+char *basic_inkey (void);
+void basic_put (const char *);
+void basic_return_error (void);
+
+void basic_profile_reset (void);
+void basic_profile_dump (void);
+void basic_profile_line (basic_num_t);
+void basic_profile_func_enter (const char *);
+void basic_profile_func_exit (const char *);
+
+int basic_strcmp (const char *, const char *);
+char *basic_read_str (void);
+void basic_restore (void);
+void basic_clear_array (void *, basic_num_t, basic_num_t);
+void *basic_dim_alloc (void *, basic_num_t, basic_num_t);
+char *basic_strdup (const char *);
+void basic_free (char *);
+basic_num_t basic_int (basic_num_t);
+basic_num_t basic_timer (void);
+char *basic_time_str (void);
+char *basic_date_str (void);
+char *basic_input_chr (int64_t);
+basic_num_t basic_peek (basic_num_t);
+void basic_poke (int64_t, int64_t);
+void basic_open (int64_t, const char *);
+void basic_close (int64_t);
+void basic_print_hash (int64_t, basic_num_t);
+void basic_print_hash_str (int64_t, const char *);
+char *basic_input_hash_str (int64_t);
+char *basic_get_hash (int64_t);
+void basic_put_hash (int64_t, const char *);
+basic_num_t basic_eof (int64_t);
+void basic_stop (void);
+void basic_set_error_handler (basic_num_t);
+basic_num_t basic_get_error_handler (void);
+void basic_set_line (basic_num_t);
+basic_num_t basic_get_line (void);
+void basic_enable_line_tracking (basic_num_t);
+void basic_delay (int64_t);
+void basic_beep (void);
+void basic_sound (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
+void basic_sound_off (void);
+basic_num_t basic_system (const char *);
+char *basic_system_out (void);
+
+typedef struct BasicData {
+  int is_str;
+  basic_num_t num;
+  char *str;
+} BasicData;
+
+extern BasicData *basic_data_items;
+extern size_t basic_data_len;
+extern size_t basic_data_pos;
+
+void basic_home (void);
+void basic_vtab (int64_t);
+void basic_randomize (basic_num_t, basic_num_t);
+basic_num_t basic_abs (basic_num_t);
+basic_num_t basic_sgn (basic_num_t);
+int64_t basic_iabs (int64_t);
+int64_t basic_isgn (int64_t);
+basic_num_t basic_sqr (basic_num_t);
+basic_num_t basic_sin (basic_num_t);
+basic_num_t basic_cos (basic_num_t);
+basic_num_t basic_tan (basic_num_t);
+basic_num_t basic_atn (basic_num_t);
+basic_num_t basic_sinh (basic_num_t);
+basic_num_t basic_cosh (basic_num_t);
+basic_num_t basic_tanh (basic_num_t);
+basic_num_t basic_asinh (basic_num_t);
+basic_num_t basic_acosh (basic_num_t);
+basic_num_t basic_atanh (basic_num_t);
+basic_num_t basic_asin (basic_num_t);
+basic_num_t basic_acos (basic_num_t);
+basic_num_t basic_log (basic_num_t);
+basic_num_t basic_log2 (basic_num_t);
+basic_num_t basic_log10 (basic_num_t);
+basic_num_t basic_exp (basic_num_t);
+basic_num_t basic_fact (basic_num_t);
+basic_num_t basic_pow (basic_num_t, basic_num_t);
+basic_num_t basic_pi (void);
+
+void basic_screen (int64_t);
+void basic_cls (void);
+void basic_color (int64_t);
+void basic_key_off (void);
+void basic_locate (int64_t, int64_t);
+void basic_tab (int64_t);
+void basic_htab (int64_t);
+void basic_text (void);
+void basic_inverse (void);
+void basic_normal (void);
+void basic_hgr2 (void);
+void basic_hcolor (basic_num_t);
+void basic_hplot (basic_num_t, basic_num_t);
+void basic_hplot_to (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
+void basic_hplot_to_current (basic_num_t, basic_num_t);
+void basic_move (basic_num_t, basic_num_t);
+void basic_draw (basic_num_t, basic_num_t);
+void basic_draw_line (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
+void basic_circle (basic_num_t, basic_num_t, basic_num_t);
+void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
+void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
+void basic_mode (basic_num_t);
+
+char *basic_chr (int64_t);
+char *basic_unichar (int64_t);
+char *basic_string (int64_t, const char *);
+char *basic_concat (const char *, const char *);
+char *basic_upper (const char *);
+char *basic_lower (const char *);
+char *basic_left (const char *, int64_t);
+char *basic_right (const char *, int64_t);
+char *basic_mid (const char *, int64_t, int64_t);
+char *basic_mirror (const char *);
+long basic_len (const char *);
+basic_num_t basic_val (const char *);
+char *basic_str (basic_num_t);
+long basic_asc (const char *);
+long basic_instr (const char *, const char *);
+
+#endif /* BASIC_RUNTIME_SHARED_H */

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -4,6 +4,10 @@
 #include "basic_runtime.h"
 #include "arena.h"
 #include "basic_pool.h"
+#ifdef BASIC_USE_FIXED64
+#include "basic_runtime_fixed64.h"
+#endif
+#include "basic_runtime_shared.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_DMOV MIR_LDMOV
@@ -88,113 +92,6 @@ static void safe_fprintf (FILE *stream, const char *fmt, ...) {
   va_end (ap);
 }
 
-/* Runtime helpers defined in basic_runtime.c */
-extern void basic_print (basic_num_t);
-extern void basic_print_str (const char *);
-extern basic_num_t basic_input (void);
-extern char *basic_input_str (void);
-extern char *basic_get (void);
-
-extern char *basic_inkey (void);
-
-extern void basic_put (const char *);
-extern void basic_return_error (void);
-
-extern void basic_profile_reset (void);
-extern void basic_profile_dump (void);
-extern void basic_profile_line (basic_num_t);
-extern void basic_profile_func_enter (const char *);
-extern void basic_profile_func_exit (const char *);
-
-extern int basic_strcmp (const char *, const char *);
-
-extern basic_num_t basic_read (void);
-extern char *basic_read_str (void);
-extern void basic_restore (void);
-extern void basic_clear_array (void *, basic_num_t, basic_num_t);
-extern void *basic_dim_alloc (void *, basic_num_t, basic_num_t);
-extern char *basic_strdup (const char *);
-extern void basic_free (char *);
-
-typedef struct BasicData {
-  int is_str;
-  basic_num_t num;
-  char *str;
-} BasicData;
-
-extern BasicData *basic_data_items;
-extern size_t basic_data_len;
-extern size_t basic_data_pos;
-
-extern void basic_home (void);
-extern void basic_vtab (int64_t);
-extern basic_num_t basic_rnd (basic_num_t);
-extern void basic_randomize (basic_num_t, basic_num_t);
-extern basic_num_t basic_abs (basic_num_t);
-extern basic_num_t basic_sgn (basic_num_t);
-extern int64_t basic_iabs (int64_t);
-extern int64_t basic_isgn (int64_t);
-extern basic_num_t basic_sqr (basic_num_t);
-extern basic_num_t basic_sin (basic_num_t);
-extern basic_num_t basic_cos (basic_num_t);
-extern basic_num_t basic_tan (basic_num_t);
-extern basic_num_t basic_atn (basic_num_t);
-extern basic_num_t basic_sinh (basic_num_t);
-extern basic_num_t basic_cosh (basic_num_t);
-extern basic_num_t basic_tanh (basic_num_t);
-extern basic_num_t basic_asinh (basic_num_t);
-extern basic_num_t basic_acosh (basic_num_t);
-extern basic_num_t basic_atanh (basic_num_t);
-extern basic_num_t basic_asin (basic_num_t);
-extern basic_num_t basic_acos (basic_num_t);
-extern basic_num_t basic_log (basic_num_t);
-extern basic_num_t basic_log2 (basic_num_t);
-extern basic_num_t basic_log10 (basic_num_t);
-extern basic_num_t basic_exp (basic_num_t);
-extern basic_num_t basic_fact (basic_num_t);
-extern basic_num_t basic_pow (basic_num_t, basic_num_t);
-extern basic_num_t basic_pi (void);
-
-extern void basic_screen (int64_t);
-extern void basic_cls (void);
-extern void basic_color (int64_t);
-extern void basic_key_off (void);
-extern void basic_locate (int64_t, int64_t);
-extern void basic_tab (int64_t);
-extern void basic_htab (int64_t);
-extern basic_num_t basic_pos (void);
-extern void basic_text (void);
-extern void basic_inverse (void);
-extern void basic_normal (void);
-extern void basic_hgr2 (void);
-extern void basic_hcolor (basic_num_t);
-extern void basic_hplot (basic_num_t, basic_num_t);
-extern void basic_hplot_to (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_hplot_to_current (basic_num_t, basic_num_t);
-extern void basic_move (basic_num_t, basic_num_t);
-extern void basic_draw (basic_num_t, basic_num_t);
-extern void basic_draw_line (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_circle (basic_num_t, basic_num_t, basic_num_t);
-extern void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_mode (basic_num_t);
-
-extern char *basic_chr (int64_t);
-extern char *basic_unichar (int64_t);
-extern char *basic_string (int64_t, const char *);
-extern char *basic_concat (const char *, const char *);
-extern char *basic_upper (const char *);
-extern char *basic_lower (const char *);
-extern char *basic_left (const char *, int64_t);
-extern char *basic_right (const char *, int64_t);
-extern char *basic_mid (const char *, int64_t, int64_t);
-extern char *basic_mirror (const char *);
-extern long basic_len (const char *);
-extern basic_num_t basic_val (const char *);
-extern char *basic_str (basic_num_t);
-extern long basic_asc (const char *);
-extern long basic_instr (const char *, const char *);
-
 static int kitty_graphics_available (void) {
   const char *id = getenv ("KITTY_WINDOW_ID");
   const char *term = getenv ("TERM");
@@ -217,38 +114,6 @@ static void *pool_realloc (void *ptr, size_t old_size, size_t new_size) {
   }
   return res;
 }
-extern basic_num_t basic_int (basic_num_t);
-extern basic_num_t basic_timer (void);
-extern char *basic_time_str (void);
-extern char *basic_date_str (void);
-extern char *basic_input_chr (int64_t);
-extern basic_num_t basic_peek (basic_num_t);
-extern void basic_poke (int64_t, int64_t);
-
-extern void basic_open (int64_t, const char *);
-extern void basic_close (int64_t);
-extern void basic_print_hash (int64_t, basic_num_t);
-extern void basic_print_hash_str (int64_t, const char *);
-extern basic_num_t basic_input_hash (int64_t);
-extern char *basic_input_hash_str (int64_t);
-extern char *basic_get_hash (int64_t);
-extern void basic_put_hash (int64_t, const char *);
-extern basic_num_t basic_eof (int64_t);
-
-extern void basic_stop (void);
-
-extern void basic_set_error_handler (basic_num_t);
-extern basic_num_t basic_get_error_handler (void);
-extern void basic_set_line (basic_num_t);
-extern basic_num_t basic_get_line (void);
-extern void basic_enable_line_tracking (basic_num_t);
-
-extern void basic_delay (int64_t);
-extern void basic_beep (void);
-extern void basic_sound (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_sound_off (void);
-extern basic_num_t basic_system (const char *);
-extern char *basic_system_out (void);
 
 static int array_base = 0;
 #define DEFAULT_ARRAY_DIM 11

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -4,6 +4,8 @@
 #include "basic_runtime.h"
 #include "arena.h"
 #include "basic_pool.h"
+#include "basic_runtime_fixed64.h"
+#include "basic_runtime_shared.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_DMOV MIR_LDMOV
@@ -270,124 +272,6 @@ static void safe_fprintf (FILE *stream, const char *fmt, ...) {
   va_end (ap);
 }
 
-/* Runtime helpers defined in basic_runtime.c */
-extern void basic_print (basic_num_t);
-extern void basic_print_str (const char *);
-#if defined(BASIC_USE_FIXED64)
-extern void basic_input (basic_num_t *);
-#else
-extern basic_num_t basic_input (void);
-#endif
-extern char *basic_input_str (void);
-extern char *basic_get (void);
-
-extern char *basic_inkey (void);
-
-extern void basic_put (const char *);
-extern void basic_return_error (void);
-
-extern void basic_profile_reset (void);
-extern void basic_profile_dump (void);
-extern void basic_profile_line (basic_num_t);
-extern void basic_profile_func_enter (const char *);
-extern void basic_profile_func_exit (const char *);
-
-extern int basic_strcmp (const char *, const char *);
-
-#if defined(BASIC_USE_FIXED64)
-extern void basic_read (basic_num_t *);
-#else
-extern basic_num_t basic_read (void);
-#endif
-extern char *basic_read_str (void);
-extern void basic_restore (void);
-extern void basic_clear_array (void *, basic_num_t, basic_num_t);
-extern void *basic_dim_alloc (void *, basic_num_t, basic_num_t);
-extern char *basic_strdup (const char *);
-extern void basic_free (char *);
-
-typedef struct BasicData {
-  int is_str;
-  basic_num_t num;
-  char *str;
-} BasicData;
-
-extern BasicData *basic_data_items;
-extern size_t basic_data_len;
-extern size_t basic_data_pos;
-
-extern void basic_home (void);
-extern void basic_vtab (int64_t);
-extern void basic_rnd (basic_num_t *, basic_num_t);
-extern void basic_randomize (basic_num_t, basic_num_t);
-extern basic_num_t basic_abs (basic_num_t);
-extern basic_num_t basic_sgn (basic_num_t);
-extern basic_num_t basic_sqr (basic_num_t);
-extern basic_num_t basic_sin (basic_num_t);
-extern basic_num_t basic_cos (basic_num_t);
-extern basic_num_t basic_tan (basic_num_t);
-extern basic_num_t basic_atn (basic_num_t);
-extern basic_num_t basic_sinh (basic_num_t);
-extern basic_num_t basic_cosh (basic_num_t);
-extern basic_num_t basic_tanh (basic_num_t);
-extern basic_num_t basic_asinh (basic_num_t);
-extern basic_num_t basic_acosh (basic_num_t);
-extern basic_num_t basic_atanh (basic_num_t);
-extern basic_num_t basic_asin (basic_num_t);
-extern basic_num_t basic_acos (basic_num_t);
-extern basic_num_t basic_log (basic_num_t);
-extern basic_num_t basic_log2 (basic_num_t);
-extern basic_num_t basic_log10 (basic_num_t);
-extern basic_num_t basic_exp (basic_num_t);
-extern basic_num_t basic_fact (basic_num_t);
-extern basic_num_t basic_pow (basic_num_t, basic_num_t);
-extern basic_num_t basic_pi (void);
-#endif
-
-extern void basic_screen (int64_t);
-extern void basic_cls (void);
-extern void basic_color (int64_t);
-extern void basic_key_off (void);
-extern void basic_locate (int64_t, int64_t);
-extern void basic_tab (int64_t);
-extern void basic_htab (int64_t);
-#if defined(BASIC_USE_FIXED64)
-extern void basic_pos (basic_num_t *);
-#else
-extern basic_num_t basic_pos (void);
-#endif
-extern void basic_text (void);
-extern void basic_inverse (void);
-extern void basic_normal (void);
-extern void basic_hgr2 (void);
-extern void basic_hcolor (basic_num_t);
-extern void basic_hplot (basic_num_t, basic_num_t);
-extern void basic_hplot_to (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_hplot_to_current (basic_num_t, basic_num_t);
-extern void basic_move (basic_num_t, basic_num_t);
-extern void basic_draw (basic_num_t, basic_num_t);
-extern void basic_draw_line (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_circle (basic_num_t, basic_num_t, basic_num_t);
-extern void basic_rect (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_fill (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_mode (basic_num_t);
-
-extern char *basic_chr_wrap (int64_t);
-extern char *basic_unichar_wrap (int64_t);
-extern char *basic_string_wrap (int64_t, const char *);
-extern char *basic_concat (const char *, const char *);
-extern char *basic_upper (const char *);
-extern char *basic_lower (const char *);
-extern char *basic_left_wrap (const char *, int64_t);
-extern char *basic_right_wrap (const char *, int64_t);
-extern char *basic_mid_wrap (const char *, int64_t, int64_t);
-extern char *basic_mirror (const char *);
-extern long basic_len (const char *);
-extern basic_num_t basic_val (const char *);
-extern char *basic_str (basic_num_t);
-extern long basic_asc (const char *);
-extern long basic_instr (const char *, const char *);
-
 static int kitty_graphics_available (void) {
   const char *id = getenv ("KITTY_WINDOW_ID");
   const char *term = getenv ("TERM");
@@ -410,59 +294,6 @@ static void *pool_realloc (void *ptr, size_t old_size, size_t new_size) {
   }
   return res;
 }
-extern basic_num_t basic_int (basic_num_t);
-extern basic_num_t basic_timer (void);
-extern char *basic_time_str (void);
-extern char *basic_date_str (void);
-extern char *basic_input_chr_wrap (int64_t);
-extern basic_num_t basic_peek (basic_num_t);
-extern void basic_poke (int64_t, int64_t);
-
-extern void basic_open (int64_t, const char *);
-extern void basic_close (int64_t);
-extern void basic_print_hash (int64_t, basic_num_t);
-extern void basic_print_hash_str (int64_t, const char *);
-#if defined(BASIC_USE_FIXED64)
-extern void basic_input_hash (basic_num_t *, int64_t);
-#else
-extern basic_num_t basic_input_hash (int64_t);
-#endif
-extern char *basic_input_hash_str (int64_t);
-extern char *basic_get_hash (int64_t);
-extern void basic_put_hash (int64_t, const char *);
-extern basic_num_t basic_eof (int64_t);
-
-#if defined(BASIC_USE_FIXED64)
-extern basic_num_t fixed64_add (basic_num_t, basic_num_t);
-extern basic_num_t fixed64_sub (basic_num_t, basic_num_t);
-extern basic_num_t fixed64_mul (basic_num_t, basic_num_t);
-extern basic_num_t fixed64_div (basic_num_t, basic_num_t);
-extern basic_num_t fixed64_neg (basic_num_t);
-extern int fixed64_eq (basic_num_t, basic_num_t);
-extern int fixed64_ne (basic_num_t, basic_num_t);
-extern int fixed64_lt (basic_num_t, basic_num_t);
-extern int fixed64_le (basic_num_t, basic_num_t);
-extern int fixed64_gt (basic_num_t, basic_num_t);
-extern int fixed64_ge (basic_num_t, basic_num_t);
-extern basic_num_t fixed64_from_int (long);
-extern basic_num_t fixed64_from_string (const char *, char **);
-extern long fixed64_to_int (basic_num_t);
-#endif
-
-extern void basic_stop (void);
-
-extern void basic_set_error_handler (basic_num_t);
-extern basic_num_t basic_get_error_handler (void);
-extern void basic_set_line (basic_num_t);
-extern basic_num_t basic_get_line (void);
-extern void basic_enable_line_tracking (basic_num_t);
-
-extern void basic_delay (int64_t);
-extern void basic_beep (void);
-extern void basic_sound (basic_num_t, basic_num_t, basic_num_t, basic_num_t);
-extern void basic_sound_off (void);
-extern basic_num_t basic_system (const char *);
-extern char *basic_system_out (void);
 
 static int array_base = 0;
 #define DEFAULT_ARRAY_DIM 11
@@ -4173,8 +4004,7 @@ static MIR_reg_t gen_expr (MIR_context_t ctx, MIR_item_t func, VarVec *vars, Nod
       char buf[32];
       safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
       MIR_reg_t argi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-      basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi),
-                     MIR_new_reg_op (ctx, arg));
+      basic_mir_n2i (ctx, func, MIR_new_reg_op (ctx, argi), MIR_new_reg_op (ctx, arg));
       MIR_append_insn (ctx, func,
                        MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, eof_proto),
                                           MIR_new_ref_op (ctx, eof_import),
@@ -4796,8 +4626,7 @@ static void gen_print_hash (Stmt *s) {
   char buf[32];
   safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
   MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                 MIR_new_reg_op (g_ctx, fn));
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
   for (size_t k = 0; k < s->u.printhash.n; k++)
     print_hash_item (fni, s->u.printhash.items[k],
                      k + 1 < s->u.printhash.n ? s->u.printhash.items[k + 1] : NULL);
@@ -4922,8 +4751,7 @@ static void gen_input_hash (Stmt *s) {
   char buf[32];
   safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
   MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                 MIR_new_reg_op (g_ctx, fn));
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t v = get_var (&g_vars, g_ctx, g_func, s->u.inputhash.var);
   (s->u.inputhash.is_str ? input_hash_str : input_hash_num) (v, fni);
 }
@@ -4938,8 +4766,7 @@ static void gen_get_hash (Stmt *s) {
   char buf[32];
   safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
   MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                 MIR_new_reg_op (g_ctx, fn));
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t v = get_var (&g_vars, g_ctx, g_func, s->u.gethash.var);
   call2 (get_hash_proto, get_hash_import, MIR_new_reg_op (g_ctx, v), MIR_new_reg_op (g_ctx, fni));
 }
@@ -4954,8 +4781,7 @@ static void gen_put_hash (Stmt *s) {
   char buf[32];
   safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
   MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                 MIR_new_reg_op (g_ctx, fn));
+  basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
   MIR_reg_t r = gen_expr (g_ctx, g_func, &g_vars, s->u.puthash.expr);
   call2 (put_hash_proto, put_hash_import, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, r));
 }
@@ -5340,8 +5166,7 @@ static void gen_stmt (Stmt *s) {
     char buf[32];
     safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
     MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                   MIR_new_reg_op (g_ctx, fn));
+    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
     MIR_reg_t path = gen_expr (g_ctx, g_func, &g_vars, s->u.open.path);
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 4, MIR_new_ref_op (g_ctx, open_proto),
@@ -5354,8 +5179,7 @@ static void gen_stmt (Stmt *s) {
     char buf[32];
     safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
     MIR_reg_t fni = MIR_new_func_reg (g_ctx, g_func->u.func, MIR_T_I64, buf);
-    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni),
-                   MIR_new_reg_op (g_ctx, fn));
+    basic_mir_n2i (g_ctx, g_func, MIR_new_reg_op (g_ctx, fni), MIR_new_reg_op (g_ctx, fn));
     MIR_append_insn (g_ctx, g_func,
                      MIR_new_call_insn (g_ctx, 3, MIR_new_ref_op (g_ctx, close_proto),
                                         MIR_new_ref_op (g_ctx, close_import),


### PR DESCRIPTION
## Summary
- centralize BASIC runtime helper declarations into `basic_runtime_shared.h`
- expose fixed64-specific helper prototypes in `basic_runtime_fixed64.h`
- include shared and fixed64 headers from compiler and runtime sources

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a040ada43483269b623a2d1d13d539