### PR TITLE
basic: deduplicate common includes

### DIFF
--- a/basic/src/basic_common.h
+++ b/basic/src/basic_common.h
@@ -1,0 +1,31 @@
+#ifndef BASIC_COMMON_H
+#define BASIC_COMMON_H
+
+#include "basic_num.h"
+#include "mir.h"
+#include "mir-gen.h"
+#include "basic_runtime.h"
+#include "arena.h"
+#include "basic_pool.h"
+#ifdef BASIC_USE_FIXED64
+#include "basic_runtime_fixed64.h"
+#endif
+#include "basic_runtime_shared.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <math.h>
+
+#ifndef BASIC_SRC_DIR
+#define BASIC_SRC_DIR "."
+#endif
+
+static int safe_snprintf (char *buf, size_t size, const char *fmt, ...);
+
+#endif /* BASIC_COMMON_H */

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -1,13 +1,4 @@
-#include "basic_num.h"
-#include "mir.h"
-#include "mir-gen.h"
-#include "basic_runtime.h"
-#include "arena.h"
-#include "basic_pool.h"
-#ifdef BASIC_USE_FIXED64
-#include "basic_runtime_fixed64.h"
-#endif
-#include "basic_runtime_shared.h"
+#include "basic_common.h"
 
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_DMOV MIR_LDMOV
@@ -33,8 +24,6 @@
 #ifndef BASIC_MIR_MOV
 #define BASIC_MIR_MOV MIR_DMOV
 #endif
-
-static int safe_snprintf (char *buf, size_t size, const char *fmt, ...);
 
 #ifndef BASIC_EMIT_NUM_CONST
 static MIR_op_t emit_num_const_default (MIR_context_t ctx, basic_num_t v) {
@@ -105,19 +94,6 @@ static void basic_mir_n2i_default (MIR_context_t ctx, MIR_item_t func, MIR_op_t 
 #else
 #define BASIC_MIR_NUM_T MIR_T_D
 #endif
-#endif
-
-#include <ctype.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <strings.h>
-#include <stdint.h>
-#include <stdarg.h>
-#include <unistd.h>
-#include <math.h>
-#ifndef BASIC_SRC_DIR
-#define BASIC_SRC_DIR "."
 #endif
 
 static void safe_fprintf (FILE *stream, const char *fmt, ...) {

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -1,15 +1,6 @@
-#include "basic_num.h"
-#include "mir.h"
-#include "mir-gen.h"
-#include "basic_runtime.h"
-#include "arena.h"
-#include "basic_pool.h"
-#include "basic_runtime_fixed64.h"
-#include "basic_runtime_shared.h"
+#include "basic_common.h"
 
 #define BASIC_MIR_MOV MIR_MOV
-
-static int safe_snprintf (char *buf, size_t size, const char *fmt, ...);
 
 static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
   fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,


### PR DESCRIPTION
## Summary
- factor shared BASIC compiler includes into new `basic_common.h`
- include `basic_common.h` from both normal and fixed64 variants
- drop duplicated `safe_snprintf` prototype from `basicc_fixed64.c`

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_68a08dc6713483269cae99b671fff0fb