### PR TITLE
basic: move fixed64 hooks into shared module

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -450,7 +450,7 @@ $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basicc-fix$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_runtime.c \
+        $(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_fixed64_hooks.c $(SRC_DIR)/basic/src/basic_runtime.c \
         $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
         $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
         $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -35,6 +35,7 @@ elseif(BASIC_NUM_MODE STREQUAL "fixed64")
   list(REMOVE_ITEM BASIC_SRCS src/basic_runtime_double.c)
   list(APPEND BASIC_SRCS
        src/basicc_fixed64.c
+       src/basic_fixed64_hooks.c
        src/basic_runtime_fixed64.c
        src/vendor/fixed64/fixed64.c
        src/vendor/kitty/kitty.c

--- a/basic/src/basic_fixed64_hooks.c
+++ b/basic/src/basic_fixed64_hooks.c
@@ -1,0 +1,200 @@
+#include "basic_fixed64_hooks.h"
+
+static int safe_snprintf (char *buf, size_t size, const char *fmt, ...) {
+  va_list ap;
+  int res;
+  va_start (ap, fmt);
+  res = vsnprintf (buf, size, fmt, ap);
+  va_end (ap);
+  if (res < 0 || (size_t) res >= size) {
+    fprintf (stderr, "safe_snprintf: truncated output\n");
+    abort ();
+  }
+  return res;
+}
+
+MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_type_t t) {
+  MIR_reg_t r;
+  if (op.mode == MIR_OP_REG) {
+    r = op.u.reg;
+  } else {
+    char buf[32];
+    static int addr_id = 0;
+    safe_snprintf (buf, sizeof (buf), "$ba%d", addr_id++);
+    r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+    MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
+  }
+  return _MIR_new_var_mem_op (ctx, t, sizeof (basic_num_t), r, MIR_NON_VAR, 1);
+}
+
+void basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
+                      MIR_op_t src1, MIR_op_t src2) {
+  MIR_item_t proto = NULL, import = NULL;
+  switch (code) {
+  case MIR_DADD:
+    proto = fixed64_add_proto;
+    import = fixed64_add_import;
+    break;
+  case MIR_DSUB:
+    proto = fixed64_sub_proto;
+    import = fixed64_sub_import;
+    break;
+  case MIR_DMUL:
+    proto = fixed64_mul_proto;
+    import = fixed64_mul_import;
+    break;
+  case MIR_DDIV:
+    proto = fixed64_div_proto;
+    import = fixed64_div_import;
+    break;
+  case MIR_DEQ:
+    proto = fixed64_eq_proto;
+    import = fixed64_eq_import;
+    break;
+  case MIR_DNE:
+    proto = fixed64_ne_proto;
+    import = fixed64_ne_import;
+    break;
+  case MIR_DLT:
+    proto = fixed64_lt_proto;
+    import = fixed64_lt_import;
+    break;
+  case MIR_DLE:
+    proto = fixed64_le_proto;
+    import = fixed64_le_import;
+    break;
+  case MIR_DGT:
+    proto = fixed64_gt_proto;
+    import = fixed64_gt_import;
+    break;
+  case MIR_DGE:
+    proto = fixed64_ge_proto;
+    import = fixed64_ge_import;
+    break;
+  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, dst, src1, src2)); return;
+  }
+  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
+  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
+  char buf[32];
+  static int tmp_id = 0;
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 6, MIR_new_ref_op (ctx, proto),
+                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, lo),
+                                      MIR_new_reg_op (ctx, hi), src1_mem, src2_mem));
+  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, lo)));
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, hi)));
+}
+
+void basic_mir_unop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
+                     MIR_op_t src) {
+  if (code == MIR_DNEG) {
+    MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
+    char buf[32];
+    static int tmp_id = 0;
+    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+    MIR_reg_t res_lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+    MIR_reg_t res_hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+    MIR_append_insn (ctx, func,
+                     MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, fixed64_neg_proto),
+                                        MIR_new_ref_op (ctx, fixed64_neg_import),
+                                        MIR_new_reg_op (ctx, res_lo), MIR_new_reg_op (ctx, res_hi),
+                                        src_mem));
+    MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
+    MIR_append_insn (ctx, func,
+                     MIR_new_insn (ctx, MIR_MOV,
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
+                                   MIR_new_reg_op (ctx, res_lo)));
+    MIR_append_insn (ctx, func,
+                     MIR_new_insn (ctx, MIR_MOV,
+                                   MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
+                                   MIR_new_reg_op (ctx, res_hi)));
+    return;
+  }
+  MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, dst, src));
+}
+
+void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t label,
+                     MIR_op_t src1, MIR_op_t src2) {
+  MIR_item_t proto = NULL, import = NULL;
+  switch (code) {
+  case MIR_DBEQ:
+    proto = fixed64_eq_proto;
+    import = fixed64_eq_import;
+    break;
+  case MIR_DBNE:
+    proto = fixed64_ne_proto;
+    import = fixed64_ne_import;
+    break;
+  case MIR_DBLT:
+    proto = fixed64_lt_proto;
+    import = fixed64_lt_import;
+    break;
+  case MIR_DBLE:
+    proto = fixed64_le_proto;
+    import = fixed64_le_import;
+    break;
+  case MIR_DBGT:
+    proto = fixed64_gt_proto;
+    import = fixed64_gt_import;
+    break;
+  case MIR_DBGE:
+    proto = fixed64_ge_proto;
+    import = fixed64_ge_import;
+    break;
+  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, label, src1, src2)); return;
+  }
+  char buf[32];
+  static int btmp_id = 0;
+  safe_snprintf (buf, sizeof (buf), "$bcmp%d", btmp_id++);
+  MIR_reg_t tmp = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
+  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto),
+                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, tmp),
+                                      src1_mem, src2_mem));
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_BNE, label, MIR_new_reg_op (ctx, tmp),
+                                 MIR_new_int_op (ctx, 0)));
+}
+
+void basic_mir_i2n (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
+  char buf[32];
+  static int tmp_id = 0;
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
+  MIR_reg_t hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, fixed64_from_int_proto),
+                                      MIR_new_ref_op (ctx, fixed64_from_int_import),
+                                      MIR_new_reg_op (ctx, lo), MIR_new_reg_op (ctx, hi), src));
+  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, lo)));
+  MIR_append_insn (ctx, func,
+                   MIR_new_insn (ctx, MIR_MOV,
+                                 MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
+                                 MIR_new_reg_op (ctx, hi)));
+}
+
+void basic_mir_n2i (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
+  MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
+  MIR_append_insn (ctx, func,
+                   MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_to_int_proto),
+                                      MIR_new_ref_op (ctx, fixed64_to_int_import), dst, src_mem));
+}

--- a/basic/src/basic_fixed64_hooks.h
+++ b/basic/src/basic_fixed64_hooks.h
@@ -1,0 +1,23 @@
+#ifndef BASIC_FIXED64_HOOKS_H
+#define BASIC_FIXED64_HOOKS_H
+
+#include "basic_common.h"
+
+MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_type_t t);
+void basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
+                      MIR_op_t src1, MIR_op_t src2);
+void basic_mir_unop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
+                     MIR_op_t src);
+void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t label,
+                     MIR_op_t src1, MIR_op_t src2);
+void basic_mir_i2n (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src);
+void basic_mir_n2i (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src);
+
+extern MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
+  fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
+  fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
+  fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
+  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_to_int_proto,
+  fixed64_to_int_import, fixed64_neg_proto, fixed64_neg_import;
+
+#endif /* BASIC_FIXED64_HOOKS_H */

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -1,8 +1,9 @@
 #include "basic_common.h"
+#include "basic_fixed64_hooks.h"
 
 #define BASIC_MIR_MOV MIR_MOV
 
-static MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
+MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub_import,
   fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
   fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
   fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
@@ -18,195 +19,10 @@ static MIR_op_t fixed64_emit_num_const (MIR_context_t ctx, basic_num_t v) {
 }
 #define BASIC_EMIT_NUM_CONST fixed64_emit_num_const
 
-static MIR_op_t basic_mem (MIR_context_t ctx, MIR_item_t func, MIR_op_t op, MIR_type_t t) {
-  MIR_reg_t r;
-  if (op.mode == MIR_OP_REG) {
-    r = op.u.reg;
-  } else {
-    char buf[32];
-    static int addr_id = 0;
-    safe_snprintf (buf, sizeof (buf), "$ba%d", addr_id++);
-    r = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-    MIR_append_insn (ctx, func, MIR_new_insn (ctx, MIR_MOV, MIR_new_reg_op (ctx, r), op));
-  }
-  return _MIR_new_var_mem_op (ctx, t, sizeof (basic_num_t), r, MIR_NON_VAR, 1);
-}
-
-static void basic_mir_binop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
-                             MIR_op_t src1, MIR_op_t src2) {
-  MIR_item_t proto = NULL, import = NULL;
-  switch (code) {
-  case MIR_DADD:
-    proto = fixed64_add_proto;
-    import = fixed64_add_import;
-    break;
-  case MIR_DSUB:
-    proto = fixed64_sub_proto;
-    import = fixed64_sub_import;
-    break;
-  case MIR_DMUL:
-    proto = fixed64_mul_proto;
-    import = fixed64_mul_import;
-    break;
-  case MIR_DDIV:
-    proto = fixed64_div_proto;
-    import = fixed64_div_import;
-    break;
-  case MIR_DEQ:
-    proto = fixed64_eq_proto;
-    import = fixed64_eq_import;
-    break;
-  case MIR_DNE:
-    proto = fixed64_ne_proto;
-    import = fixed64_ne_import;
-    break;
-  case MIR_DLT:
-    proto = fixed64_lt_proto;
-    import = fixed64_lt_import;
-    break;
-  case MIR_DLE:
-    proto = fixed64_le_proto;
-    import = fixed64_le_import;
-    break;
-  case MIR_DGT:
-    proto = fixed64_gt_proto;
-    import = fixed64_gt_import;
-    break;
-  case MIR_DGE:
-    proto = fixed64_ge_proto;
-    import = fixed64_ge_import;
-    break;
-  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, dst, src1, src2)); return;
-  }
-  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
-  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
-  char buf[32];
-  static int tmp_id = 0;
-  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-  MIR_reg_t lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-  MIR_reg_t hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  MIR_append_insn (ctx, func,
-                   MIR_new_call_insn (ctx, 6, MIR_new_ref_op (ctx, proto),
-                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, lo),
-                                      MIR_new_reg_op (ctx, hi), src1_mem, src2_mem));
-  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_MOV,
-                                 MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
-                                 MIR_new_reg_op (ctx, lo)));
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_MOV,
-                                 MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
-                                 MIR_new_reg_op (ctx, hi)));
-}
 #define BASIC_MIR_BINOP basic_mir_binop
-
-static void basic_mir_unop (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code, MIR_op_t dst,
-                            MIR_op_t src) {
-  if (code == MIR_DNEG) {
-    MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
-    char buf[32];
-    static int tmp_id = 0;
-    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-    MIR_reg_t res_lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-    safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-    MIR_reg_t res_hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-    MIR_append_insn (ctx, func,
-                     MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, fixed64_neg_proto),
-                                        MIR_new_ref_op (ctx, fixed64_neg_import),
-                                        MIR_new_reg_op (ctx, res_lo), MIR_new_reg_op (ctx, res_hi),
-                                        src_mem));
-    MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
-    MIR_append_insn (ctx, func,
-                     MIR_new_insn (ctx, MIR_MOV,
-                                   MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
-                                   MIR_new_reg_op (ctx, res_lo)));
-    MIR_append_insn (ctx, func,
-                     MIR_new_insn (ctx, MIR_MOV,
-                                   MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
-                                   MIR_new_reg_op (ctx, res_hi)));
-    return;
-  }
-  MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, dst, src));
-}
 #define BASIC_MIR_UNOP basic_mir_unop
-
-static void basic_mir_bcmp (MIR_context_t ctx, MIR_item_t func, MIR_insn_code_t code,
-                            MIR_op_t label, MIR_op_t src1, MIR_op_t src2) {
-  MIR_item_t proto = NULL, import = NULL;
-  switch (code) {
-  case MIR_DBEQ:
-    proto = fixed64_eq_proto;
-    import = fixed64_eq_import;
-    break;
-  case MIR_DBNE:
-    proto = fixed64_ne_proto;
-    import = fixed64_ne_import;
-    break;
-  case MIR_DBLT:
-    proto = fixed64_lt_proto;
-    import = fixed64_lt_import;
-    break;
-  case MIR_DBLE:
-    proto = fixed64_le_proto;
-    import = fixed64_le_import;
-    break;
-  case MIR_DBGT:
-    proto = fixed64_gt_proto;
-    import = fixed64_gt_import;
-    break;
-  case MIR_DBGE:
-    proto = fixed64_ge_proto;
-    import = fixed64_ge_import;
-    break;
-  default: MIR_append_insn (ctx, func, MIR_new_insn (ctx, code, label, src1, src2)); return;
-  }
-  char buf[32];
-  static int btmp_id = 0;
-  safe_snprintf (buf, sizeof (buf), "$bcmp%d", btmp_id++);
-  MIR_reg_t tmp = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  MIR_op_t src1_mem = basic_mem (ctx, func, src1, MIR_T_BLK);
-  MIR_op_t src2_mem = basic_mem (ctx, func, src2, MIR_T_BLK);
-  MIR_append_insn (ctx, func,
-                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, proto),
-                                      MIR_new_ref_op (ctx, import), MIR_new_reg_op (ctx, tmp),
-                                      src1_mem, src2_mem));
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_BNE, label, MIR_new_reg_op (ctx, tmp),
-                                 MIR_new_int_op (ctx, 0)));
-}
 #define BASIC_MIR_BCMP basic_mir_bcmp
-
-static void basic_mir_i2n (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
-  char buf[32];
-  static int tmp_id = 0;
-  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-  MIR_reg_t lo = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  safe_snprintf (buf, sizeof (buf), "$t%d", tmp_id++);
-  MIR_reg_t hi = MIR_new_func_reg (ctx, func->u.func, MIR_T_I64, buf);
-  MIR_append_insn (ctx, func,
-                   MIR_new_call_insn (ctx, 5, MIR_new_ref_op (ctx, fixed64_from_int_proto),
-                                      MIR_new_ref_op (ctx, fixed64_from_int_import),
-                                      MIR_new_reg_op (ctx, lo), MIR_new_reg_op (ctx, hi), src));
-  MIR_op_t dst_mem = basic_mem (ctx, func, dst, MIR_T_BLK);
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_MOV,
-                                 MIR_new_mem_op (ctx, MIR_T_I64, 0, dst_mem.u.mem.base, 0, 1),
-                                 MIR_new_reg_op (ctx, lo)));
-  MIR_append_insn (ctx, func,
-                   MIR_new_insn (ctx, MIR_MOV,
-                                 MIR_new_mem_op (ctx, MIR_T_I64, 8, dst_mem.u.mem.base, 0, 1),
-                                 MIR_new_reg_op (ctx, hi)));
-}
 #define BASIC_MIR_I2N basic_mir_i2n
-
-static void basic_mir_n2i (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src) {
-  MIR_op_t src_mem = basic_mem (ctx, func, src, MIR_T_BLK);
-  MIR_append_insn (ctx, func,
-                   MIR_new_call_insn (ctx, 4, MIR_new_ref_op (ctx, fixed64_to_int_proto),
-                                      MIR_new_ref_op (ctx, fixed64_to_int_import), dst, src_mem));
-}
 #define BASIC_MIR_N2I basic_mir_n2i
 
 static void basic_fixed64_init (MIR_context_t ctx) {


### PR DESCRIPTION
## Summary
- centralize fixed64 MIR helpers in `basic_fixed64_hooks.[ch]`
- include and map hook macros in `basicc_fixed64.c`
- compile hooks via build rules

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a09be551f883269d6e01f23c30d1aa