### PR TITLE
Adjust numeric helper prototypes for fixed64 runtime

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -96,6 +96,14 @@ static void basic_mir_n2i_default (MIR_context_t ctx, MIR_item_t func, MIR_op_t 
 #endif
 #endif
 
+#if defined(BASIC_USE_FIXED64)
+#define BASIC_PROTO_NUM(ctx, name, nargs, ...) \
+  MIR_new_proto (ctx, name, 0, NULL, (nargs) + 1, MIR_T_P, "res", ##__VA_ARGS__)
+#else
+#define BASIC_PROTO_NUM(ctx, name, nargs, ...) \
+  MIR_new_proto (ctx, name, 1, &d, nargs, ##__VA_ARGS__)
+#endif
+
 static void safe_fprintf (FILE *stream, const char *fmt, ...) {
   va_list ap;
   va_start (ap, fmt);
@@ -6010,7 +6018,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   prints_proto = MIR_new_proto (ctx, "basic_print_str_p", 0, NULL, 1, MIR_T_P, "s");
   prints_import = MIR_new_import (ctx, "basic_print_str");
   MIR_type_t d = BASIC_MIR_NUM_T;
-  input_proto = MIR_new_proto (ctx, "basic_input_p", 1, &d, 0);
+  input_proto = BASIC_PROTO_NUM (ctx, "basic_input_p", 0);
   input_import = MIR_new_import (ctx, "basic_input");
   MIR_type_t p = MIR_T_P;
   MIR_type_t i = MIR_T_I64;
@@ -6030,7 +6038,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   prinths_proto
     = MIR_new_proto (ctx, "basic_print_hash_str_p", 0, NULL, 2, MIR_T_I64, "n", MIR_T_P, "s");
   prinths_import = MIR_new_import (ctx, "basic_print_hash_str");
-  input_hash_proto = MIR_new_proto (ctx, "basic_input_hash_p", 1, &d, 1, MIR_T_I64, "n");
+  input_hash_proto = BASIC_PROTO_NUM (ctx, "basic_input_hash_p", 1, MIR_T_I64, "n");
   input_hash_import = MIR_new_import (ctx, "basic_input_hash");
   input_hash_str_proto = MIR_new_proto (ctx, "basic_input_hash_str_p", 1, &p, 1, MIR_T_I64, "n");
   input_hash_str_import = MIR_new_import (ctx, "basic_input_hash_str");
@@ -6147,7 +6155,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
       = MIR_new_proto (ctx, "basic_profile_func_exit_p", 0, NULL, 1, MIR_T_P, "name");
     profile_func_exit_import = MIR_new_import (ctx, "basic_profile_func_exit");
   }
-  rnd_proto = MIR_new_proto (ctx, "basic_rnd_p", 1, &d, 1, BASIC_MIR_NUM_T, "n");
+  rnd_proto = BASIC_PROTO_NUM (ctx, "basic_rnd_p", 1, BASIC_MIR_NUM_T, "n");
   rnd_import = MIR_new_import (ctx, "basic_rnd");
   chr_proto = MIR_new_proto (ctx, "basic_chr_p", 1, &p, 1, MIR_T_I64, "n");
   chr_import = MIR_new_import (ctx, "basic_chr");
@@ -6173,7 +6181,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   peek_import = MIR_new_import (ctx, "basic_peek");
   eof_proto = MIR_new_proto (ctx, "basic_eof_p", 1, &d, 1, MIR_T_I64, "n");
   eof_import = MIR_new_import (ctx, "basic_eof");
-  pos_proto = MIR_new_proto (ctx, "basic_pos_p", 1, &d, 0);
+  pos_proto = BASIC_PROTO_NUM (ctx, "basic_pos_p", 0);
   pos_import = MIR_new_import (ctx, "basic_pos");
 
   abs_proto = MIR_new_proto (ctx, "basic_abs_p", 1, &d, 1, BASIC_MIR_NUM_T, "x");
@@ -6297,7 +6305,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   MIR_type_t i64 = MIR_T_I64;
   strcmp_proto = MIR_new_proto (ctx, "basic_strcmp_p", 1, &i64, 2, MIR_T_P, "a", MIR_T_P, "b");
   strcmp_import = MIR_new_import (ctx, "basic_strcmp");
-  read_proto = MIR_new_proto (ctx, "basic_read_p", 1, &d, 0);
+  read_proto = BASIC_PROTO_NUM (ctx, "basic_read_p", 0);
   read_import = MIR_new_import (ctx, "basic_read");
   read_str_proto = MIR_new_proto (ctx, "basic_read_str_p", 1, &p, 0);
   read_str_import = MIR_new_import (ctx, "basic_read_str");


### PR DESCRIPTION
## Summary
- add BASIC_PROTO_NUM macro to switch numeric helper prototypes between value-return and pointer-return conventions
- fix prototypes for input, input hash, position, read, and rnd helpers under BASIC_USE_FIXED64

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c389122c83268309116043c1b422