### PR TITLE
Remove unused fixed64 string conversion artifacts

### DIFF
--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -1148,9 +1148,7 @@ static Token read_token (Parser *p) {
     }
   }
   if (isdigit (c) || c == '.') {
-    char *start = cur;
-    t.num = BASIC_STRTOF (cur, &cur);
-    (void) start;
+    t.num = basic_num_from_string (cur, &cur);
     t.type = TOK_NUMBER;
     decimal_locked = 1;
     p->cur = cur;

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -7,9 +7,8 @@ MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub
   fixed64_mul_proto, fixed64_mul_import, fixed64_div_proto, fixed64_div_import, fixed64_eq_proto,
   fixed64_eq_import, fixed64_ne_proto, fixed64_ne_import, fixed64_lt_proto, fixed64_lt_import,
   fixed64_le_proto, fixed64_le_import, fixed64_gt_proto, fixed64_gt_import, fixed64_ge_proto,
-  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_from_string_proto,
-  fixed64_from_string_import, fixed64_to_int_proto, fixed64_to_int_import, fixed64_neg_proto,
-  fixed64_neg_import;
+  fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_to_int_proto,
+  fixed64_to_int_import, fixed64_neg_proto, fixed64_neg_import;
 
 static MIR_op_t fixed64_emit_num_const (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
@@ -76,15 +75,6 @@ static void basic_fixed64_init (MIR_context_t ctx) {
   int_vars[0].type = MIR_T_I64;
   fixed64_from_int_proto = MIR_new_proto_arr (ctx, "fixed64_from_int_p", 2, i64_pair, 1, int_vars);
   fixed64_from_int_import = MIR_new_import (ctx, "fixed64_from_int");
-
-  MIR_var_t str_vars[2];
-  str_vars[0].name = "s";
-  str_vars[0].type = MIR_T_P;
-  str_vars[1].name = "end";
-  str_vars[1].type = MIR_T_P;
-  fixed64_from_string_proto
-    = MIR_new_proto_arr (ctx, "fixed64_from_string_p", 2, i64_pair, 2, str_vars);
-  fixed64_from_string_import = MIR_new_import (ctx, "fixed64_from_string");
 
   MIR_var_t to_int_vars[1];
   to_int_vars[0].name = "a";


### PR DESCRIPTION
## Summary
- Drop unused fixed64_from_string proto/import from the fixed64 BASIC compiler setup
- Parse numeric literals through basic_num_from_string so it's the canonical conversion path

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d552b68c8326a282459c4ce8b454