### PR TITLE
Fix MIR handle helpers for fixed-point BASIC

### DIFF
--- a/basic/include/basic_runtime.h
+++ b/basic/include/basic_runtime.h
@@ -18,6 +18,21 @@ long basic_len (const char *s);
 long basic_instr (const char *s, const char *sub);
 long basic_asc (const char *s);
 
+#ifdef BASIC_USE_FIXED64
+void basic_mir_ctx (basic_num_t *res);
+void basic_mir_mod (basic_num_t *res, basic_num_t ctx, const char *name);
+void basic_mir_func (basic_num_t *res, basic_num_t mod, const char *name, basic_num_t nargs);
+void basic_mir_reg (basic_num_t *res, basic_num_t func);
+void basic_mir_label (basic_num_t *res, basic_num_t func);
+void basic_mir_emit (basic_num_t *res, basic_num_t func, const char *op, basic_num_t a,
+                     basic_num_t b, basic_num_t c);
+void basic_mir_emitlbl (basic_num_t *res, basic_num_t func, basic_num_t label);
+void basic_mir_ret (basic_num_t *res, basic_num_t func, basic_num_t reg);
+void basic_mir_finish (basic_num_t *res, basic_num_t mod);
+void basic_mir_run (basic_num_t *res, basic_num_t func, basic_num_t a1, basic_num_t a2,
+                    basic_num_t a3, basic_num_t a4);
+void basic_mir_dump (basic_num_t *res, basic_num_t func);
+#else
 basic_num_t basic_mir_ctx (void);
 basic_num_t basic_mir_mod (basic_num_t ctx, const char *name);
 basic_num_t basic_mir_func (basic_num_t mod, const char *name, basic_num_t nargs);
@@ -31,6 +46,7 @@ basic_num_t basic_mir_finish (basic_num_t mod);
 basic_num_t basic_mir_run (basic_num_t func, basic_num_t a1, basic_num_t a2, basic_num_t a3,
                            basic_num_t a4);
 basic_num_t basic_mir_dump (basic_num_t func);
+#endif
 
 void *basic_dim_alloc (void *base, basic_num_t len, basic_num_t is_str);
 void basic_clear_array (void *base, basic_num_t len, basic_num_t is_str);

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -1162,9 +1162,13 @@ static basic_num_t basic_mir_ctx_impl (void) {
   return ctx_handle;
 }
 
+#ifdef BASIC_USE_FIXED64
+void basic_mir_ctx (basic_num_t *res) { *res = basic_mir_ctx_impl (); }
+#else
 basic_num_t basic_mir_ctx (void) { return basic_mir_ctx_impl (); }
+#endif
 
-basic_num_t basic_mir_mod (basic_num_t ctx_h, const char *name) {
+static basic_num_t basic_mir_mod_impl (basic_num_t ctx_h, const char *name) {
   Handle *h = get_handle (ctx_h);
   if (h == NULL || h->kind != H_CTX) return BASIC_ZERO;
   MIR_context_t ctx = h->ctx;
@@ -1173,7 +1177,17 @@ basic_num_t basic_mir_mod (basic_num_t ctx_h, const char *name) {
   return new_handle (H_MOD, ctx, mod);
 }
 
-basic_num_t basic_mir_func (basic_num_t mod_h, const char *name, basic_num_t nargs_d) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_mod (basic_num_t *res, basic_num_t ctx_h, const char *name) {
+  *res = basic_mir_mod_impl (ctx_h, name);
+}
+#else
+basic_num_t basic_mir_mod (basic_num_t ctx_h, const char *name) {
+  return basic_mir_mod_impl (ctx_h, name);
+}
+#endif
+
+static basic_num_t basic_mir_func_impl (basic_num_t mod_h, const char *name, basic_num_t nargs_d) {
   Handle *h = get_handle (mod_h);
   if (h == NULL || h->kind != H_MOD) return BASIC_ZERO;
   MIR_context_t ctx = h->ctx;
@@ -1195,7 +1209,17 @@ basic_num_t basic_mir_func (basic_num_t mod_h, const char *name, basic_num_t nar
   return new_handle (H_FUNC, ctx, fh);
 }
 
-basic_num_t basic_mir_reg (basic_num_t func_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_func (basic_num_t *res, basic_num_t mod_h, const char *name, basic_num_t nargs_d) {
+  *res = basic_mir_func_impl (mod_h, name, nargs_d);
+}
+#else
+basic_num_t basic_mir_func (basic_num_t mod_h, const char *name, basic_num_t nargs_d) {
+  return basic_mir_func_impl (mod_h, name, nargs_d);
+}
+#endif
+
+static basic_num_t basic_mir_reg_impl (basic_num_t func_h) {
   Handle *h = get_handle (func_h);
   if (h == NULL || h->kind != H_FUNC) return BASIC_ZERO;
   FuncHandle *fh = h->ptr;
@@ -1212,7 +1236,13 @@ basic_num_t basic_mir_reg (basic_num_t func_h) {
   return new_handle (H_REG, ctx, (void *) (uintptr_t) r);
 }
 
-basic_num_t basic_mir_label (basic_num_t func_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_reg (basic_num_t *res, basic_num_t func_h) { *res = basic_mir_reg_impl (func_h); }
+#else
+basic_num_t basic_mir_reg (basic_num_t func_h) { return basic_mir_reg_impl (func_h); }
+#endif
+
+static basic_num_t basic_mir_label_impl (basic_num_t func_h) {
   Handle *h = get_handle (func_h);
   if (h == NULL || h->kind != H_FUNC) return BASIC_ZERO;
   MIR_context_t ctx = h->ctx;
@@ -1220,8 +1250,16 @@ basic_num_t basic_mir_label (basic_num_t func_h) {
   return new_handle (H_LABEL, ctx, (void *) lab);
 }
 
-basic_num_t basic_mir_emit (basic_num_t func_h, const char *op, basic_num_t a, basic_num_t b,
-                            basic_num_t c) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_label (basic_num_t *res, basic_num_t func_h) {
+  *res = basic_mir_label_impl (func_h);
+}
+#else
+basic_num_t basic_mir_label (basic_num_t func_h) { return basic_mir_label_impl (func_h); }
+#endif
+
+static basic_num_t basic_mir_emit_impl (basic_num_t func_h, const char *op, basic_num_t a,
+                                        basic_num_t b, basic_num_t c) {
   Handle *h = get_handle (func_h);
   if (h == NULL || h->kind != H_FUNC) return BASIC_ZERO;
   FuncHandle *fh = h->ptr;
@@ -1256,7 +1294,19 @@ basic_num_t basic_mir_emit (basic_num_t func_h, const char *op, basic_num_t a, b
   return BASIC_ZERO;
 }
 
-basic_num_t basic_mir_emitlbl (basic_num_t func_h, basic_num_t lab_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_emit (basic_num_t *res, basic_num_t func_h, const char *op, basic_num_t a,
+                     basic_num_t b, basic_num_t c) {
+  *res = basic_mir_emit_impl (func_h, op, a, b, c);
+}
+#else
+basic_num_t basic_mir_emit (basic_num_t func_h, const char *op, basic_num_t a, basic_num_t b,
+                            basic_num_t c) {
+  return basic_mir_emit_impl (func_h, op, a, b, c);
+}
+#endif
+
+static basic_num_t basic_mir_emitlbl_impl (basic_num_t func_h, basic_num_t lab_h) {
   Handle *fh = get_handle (func_h);
   Handle *lh = get_handle (lab_h);
   if (fh == NULL || lh == NULL || fh->kind != H_FUNC || lh->kind != H_LABEL) return BASIC_ZERO;
@@ -1265,7 +1315,17 @@ basic_num_t basic_mir_emitlbl (basic_num_t func_h, basic_num_t lab_h) {
   return BASIC_ZERO;
 }
 
-basic_num_t basic_mir_ret (basic_num_t func_h, basic_num_t reg_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_emitlbl (basic_num_t *res, basic_num_t func_h, basic_num_t lab_h) {
+  *res = basic_mir_emitlbl_impl (func_h, lab_h);
+}
+#else
+basic_num_t basic_mir_emitlbl (basic_num_t func_h, basic_num_t lab_h) {
+  return basic_mir_emitlbl_impl (func_h, lab_h);
+}
+#endif
+
+static basic_num_t basic_mir_ret_impl (basic_num_t func_h, basic_num_t reg_h) {
   Handle *fh = get_handle (func_h);
   Handle *rh = get_handle (reg_h);
   if (fh == NULL || rh == NULL || fh->kind != H_FUNC || rh->kind != H_REG) return BASIC_ZERO;
@@ -1277,7 +1337,17 @@ basic_num_t basic_mir_ret (basic_num_t func_h, basic_num_t reg_h) {
   return BASIC_ZERO;
 }
 
-basic_num_t basic_mir_finish (basic_num_t mod_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_ret (basic_num_t *res, basic_num_t func_h, basic_num_t reg_h) {
+  *res = basic_mir_ret_impl (func_h, reg_h);
+}
+#else
+basic_num_t basic_mir_ret (basic_num_t func_h, basic_num_t reg_h) {
+  return basic_mir_ret_impl (func_h, reg_h);
+}
+#endif
+
+static basic_num_t basic_mir_finish_impl (basic_num_t mod_h) {
   Handle *mh = get_handle (mod_h);
   if (mh == NULL || mh->kind != H_MOD) return BASIC_ZERO;
   MIR_context_t ctx = mh->ctx;
@@ -1288,8 +1358,16 @@ basic_num_t basic_mir_finish (basic_num_t mod_h) {
   return BASIC_ZERO;
 }
 
-basic_num_t basic_mir_run (basic_num_t func_h, basic_num_t a1, basic_num_t a2, basic_num_t a3,
-                           basic_num_t a4) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_finish (basic_num_t *res, basic_num_t mod_h) {
+  *res = basic_mir_finish_impl (mod_h);
+}
+#else
+basic_num_t basic_mir_finish (basic_num_t mod_h) { return basic_mir_finish_impl (mod_h); }
+#endif
+
+static basic_num_t basic_mir_run_impl (basic_num_t func_h, basic_num_t a1, basic_num_t a2,
+                                       basic_num_t a3, basic_num_t a4) {
   Handle *fh = get_handle (func_h);
   if (fh == NULL || fh->kind != H_FUNC) return BASIC_ZERO;
   FuncHandle *f = fh->ptr;
@@ -1313,12 +1391,30 @@ basic_num_t basic_mir_run (basic_num_t func_h, basic_num_t a1, basic_num_t a2, b
   return res;
 }
 
-basic_num_t basic_mir_dump (basic_num_t func_h) {
+#ifdef BASIC_USE_FIXED64
+void basic_mir_run (basic_num_t *res, basic_num_t func_h, basic_num_t a1, basic_num_t a2,
+                    basic_num_t a3, basic_num_t a4) {
+  *res = basic_mir_run_impl (func_h, a1, a2, a3, a4);
+}
+#else
+basic_num_t basic_mir_run (basic_num_t func_h, basic_num_t a1, basic_num_t a2, basic_num_t a3,
+                           basic_num_t a4) {
+  return basic_mir_run_impl (func_h, a1, a2, a3, a4);
+}
+#endif
+
+static basic_num_t basic_mir_dump_impl (basic_num_t func_h) {
   Handle *fh = get_handle (func_h);
   if (fh == NULL || fh->kind != H_FUNC) return BASIC_ZERO;
   FuncHandle *f = fh->ptr;
   MIR_output_item (fh->ctx, stdout, f->item);
   return BASIC_ZERO;
 }
+
+#ifdef BASIC_USE_FIXED64
+void basic_mir_dump (basic_num_t *res, basic_num_t func_h) { *res = basic_mir_dump_impl (func_h); }
+#else
+basic_num_t basic_mir_dump (basic_num_t func_h) { return basic_mir_dump_impl (func_h); }
+#endif
 
 void __attribute__ ((weak)) basic_eval (const char *cmd) { (void) cmd; }

--- a/basic/src/basicc_core.c
+++ b/basic/src/basicc_core.c
@@ -5998,7 +5998,6 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   print_import = MIR_new_import (ctx, "basic_print");
   prints_proto = MIR_new_proto (ctx, "basic_print_str_p", 0, NULL, 1, MIR_T_P, "s");
   prints_import = MIR_new_import (ctx, "basic_print_str");
-  MIR_type_t d = BASIC_MIR_NUM_T;
   input_proto = BASIC_PROTO_NUM (ctx, "basic_input_p", 0);
   input_import = MIR_new_import (ctx, "basic_input");
   MIR_type_t p = MIR_T_P;
@@ -6244,37 +6243,35 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   strdup_import = MIR_new_import (ctx, "basic_strdup");
   free_proto = MIR_new_proto (ctx, "basic_free_p", 0, NULL, 1, MIR_T_P, "s");
   free_import = MIR_new_import (ctx, "basic_free");
-  mir_ctx_proto = MIR_new_proto (ctx, "basic_mir_ctx_p", 1, &d, 0);
+  mir_ctx_proto = BASIC_PROTO_NUM (ctx, "basic_mir_ctx_p", 0);
   mir_ctx_import = MIR_new_import (ctx, "basic_mir_ctx");
-  mir_mod_proto
-    = MIR_new_proto (ctx, "basic_mir_mod_p", 1, &d, 2, BASIC_MIR_NUM_T, "ctx", MIR_T_P, "name");
+  mir_mod_proto = BASIC_PROTO_NUM (ctx, "basic_mir_mod_p", 2, {BASIC_MIR_NUM_T, "ctx", 0},
+                                   {MIR_T_P, "name", 0});
   mir_mod_import = MIR_new_import (ctx, "basic_mir_mod");
-  mir_func_proto = MIR_new_proto (ctx, "basic_mir_func_p", 1, &d, 3, BASIC_MIR_NUM_T, "mod",
-                                  MIR_T_P, "name", BASIC_MIR_NUM_T, "nargs");
+  mir_func_proto = BASIC_PROTO_NUM (ctx, "basic_mir_func_p", 3, {BASIC_MIR_NUM_T, "mod", 0},
+                                    {MIR_T_P, "name", 0}, {BASIC_MIR_NUM_T, "nargs", 0});
   mir_func_import = MIR_new_import (ctx, "basic_mir_func");
-  mir_reg_proto = MIR_new_proto (ctx, "basic_mir_reg_p", 1, &d, 1, BASIC_MIR_NUM_T, "func");
+  mir_reg_proto = BASIC_PROTO_NUM (ctx, "basic_mir_reg_p", 1, {BASIC_MIR_NUM_T, "func", 0});
   mir_reg_import = MIR_new_import (ctx, "basic_mir_reg");
-  mir_label_proto = MIR_new_proto (ctx, "basic_mir_label_p", 1, &d, 1, BASIC_MIR_NUM_T, "func");
+  mir_label_proto = BASIC_PROTO_NUM (ctx, "basic_mir_label_p", 1, {BASIC_MIR_NUM_T, "func", 0});
   mir_label_import = MIR_new_import (ctx, "basic_mir_label");
-  mir_emit_proto
-    = MIR_new_proto (ctx, "basic_mir_emit_p", 1, &d, 5, BASIC_MIR_NUM_T, "func", MIR_T_P, "op",
-                     BASIC_MIR_NUM_T, "a", BASIC_MIR_NUM_T, "b", BASIC_MIR_NUM_T, "c");
+  mir_emit_proto = BASIC_PROTO_NUM (ctx, "basic_mir_emit_p", 5, {BASIC_MIR_NUM_T, "func", 0},
+                                    {MIR_T_P, "op", 0}, {BASIC_MIR_NUM_T, "a", 0},
+                                    {BASIC_MIR_NUM_T, "b", 0}, {BASIC_MIR_NUM_T, "c", 0});
   mir_emit_import = MIR_new_import (ctx, "basic_mir_emit");
-  mir_emitlbl_proto = MIR_new_proto (ctx, "basic_mir_emitlbl_p", 1, &d, 2, BASIC_MIR_NUM_T, "func",
-                                     BASIC_MIR_NUM_T, "lab");
+  mir_emitlbl_proto = BASIC_PROTO_NUM (ctx, "basic_mir_emitlbl_p", 2, {BASIC_MIR_NUM_T, "func", 0},
+                                       {BASIC_MIR_NUM_T, "lab", 0});
   mir_emitlbl_import = MIR_new_import (ctx, "basic_mir_emitlbl");
-  mir_ret_proto = MIR_new_proto (ctx, "basic_mir_ret_p", 1, &d, 2, BASIC_MIR_NUM_T, "func",
-                                 BASIC_MIR_NUM_T, "reg");
+  mir_ret_proto = BASIC_PROTO_NUM (ctx, "basic_mir_ret_p", 2, {BASIC_MIR_NUM_T, "func", 0},
+                                   {BASIC_MIR_NUM_T, "reg", 0});
   mir_ret_import = MIR_new_import (ctx, "basic_mir_ret");
-  mir_finish_proto = MIR_new_proto (ctx, "basic_mir_finish_p", 1, &d, 1, BASIC_MIR_NUM_T, "mod");
+  mir_finish_proto = BASIC_PROTO_NUM (ctx, "basic_mir_finish_p", 1, {BASIC_MIR_NUM_T, "mod", 0});
   mir_finish_import = MIR_new_import (ctx, "basic_mir_finish");
-  {
-    mir_run_proto
-      = MIR_new_proto (ctx, "basic_mir_run_p", 1, &d, 5, BASIC_MIR_NUM_T, "func", BASIC_MIR_NUM_T,
-                       "a1", BASIC_MIR_NUM_T, "a2", BASIC_MIR_NUM_T, "a3", BASIC_MIR_NUM_T, "a4");
-  }
+  mir_run_proto = BASIC_PROTO_NUM (ctx, "basic_mir_run_p", 5, {BASIC_MIR_NUM_T, "func", 0},
+                                   {BASIC_MIR_NUM_T, "a1", 0}, {BASIC_MIR_NUM_T, "a2", 0},
+                                   {BASIC_MIR_NUM_T, "a3", 0}, {BASIC_MIR_NUM_T, "a4", 0});
   mir_run_import = MIR_new_import (ctx, "basic_mir_run");
-  mir_dump_proto = MIR_new_proto (ctx, "basic_mir_dump_p", 1, &d, 1, BASIC_MIR_NUM_T, "func");
+  mir_dump_proto = BASIC_PROTO_NUM (ctx, "basic_mir_dump_p", 1, {BASIC_MIR_NUM_T, "func", 0});
   mir_dump_import = MIR_new_import (ctx, "basic_mir_dump");
 
   calloc_proto = MIR_new_proto (ctx, "calloc_p", 1, &p, 2, MIR_T_I64, "n", MIR_T_I64, "sz");

--- a/basic/test/basic_handle_fixed64_test.c
+++ b/basic/test/basic_handle_fixed64_test.c
@@ -5,33 +5,34 @@
 #include "basic_runtime.h"
 
 int main (void) {
-  basic_num_t ctx = basic_mir_ctx ();
+  basic_num_t ctx, ctx2, mod, func, r1, r2, r3, lbl, dummy, res;
+  basic_mir_ctx (&ctx);
   assert (basic_num_ne (ctx, BASIC_ZERO));
-  basic_num_t ctx2 = basic_mir_ctx ();
+  basic_mir_ctx (&ctx2);
   assert (basic_num_eq (ctx, ctx2));
 
-  basic_num_t mod = basic_mir_mod (ctx, "tmod");
+  basic_mir_mod (&mod, ctx, "tmod");
   assert (basic_num_ne (mod, BASIC_ZERO));
-  basic_num_t func = basic_mir_func (mod, "tfunc", BASIC_ZERO);
+  basic_mir_func (&func, mod, "tfunc", BASIC_ZERO);
   assert (basic_num_ne (func, BASIC_ZERO));
-  basic_num_t r1 = basic_mir_reg (func);
-  basic_num_t r2 = basic_mir_reg (func);
-  basic_num_t r3 = basic_mir_reg (func);
-  basic_num_t lbl = basic_mir_label (func);
+  basic_mir_reg (&r1, func);
+  basic_mir_reg (&r2, func);
+  basic_mir_reg (&r3, func);
+  basic_mir_label (&lbl, func);
   assert (basic_num_ne (r1, BASIC_ZERO));
   assert (basic_num_ne (r2, BASIC_ZERO));
   assert (basic_num_ne (r3, BASIC_ZERO));
   assert (basic_num_ne (lbl, BASIC_ZERO));
-  basic_mir_emitlbl (func, lbl);
-  basic_mir_emit (func, "DMOV", r1, basic_num_from_int (2), BASIC_ZERO);
-  basic_mir_emit (func, "DMOV", r2, basic_num_from_int (3), BASIC_ZERO);
-  basic_mir_emit (func, "MOV", r3, r1, BASIC_ZERO);
-  basic_mir_emit (func, "DADD", r3, r3, r2);
-  basic_mir_emit (func, "MOV", r1, r3, BASIC_ZERO);
-  basic_mir_emit (func, "DNEG", r1, r1, BASIC_ZERO);
-  basic_mir_ret (func, r1);
-  basic_mir_finish (mod);
-  basic_num_t res = basic_mir_run (func, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO);
+  basic_mir_emitlbl (&dummy, func, lbl);
+  basic_mir_emit (&dummy, func, "DMOV", r1, basic_num_from_int (2), BASIC_ZERO);
+  basic_mir_emit (&dummy, func, "DMOV", r2, basic_num_from_int (3), BASIC_ZERO);
+  basic_mir_emit (&dummy, func, "MOV", r3, r1, BASIC_ZERO);
+  basic_mir_emit (&dummy, func, "DADD", r3, r3, r2);
+  basic_mir_emit (&dummy, func, "MOV", r1, r3, BASIC_ZERO);
+  basic_mir_emit (&dummy, func, "DNEG", r1, r1, BASIC_ZERO);
+  basic_mir_ret (&dummy, func, r1);
+  basic_mir_finish (&dummy, mod);
+  basic_mir_run (&res, func, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO);
   assert (basic_num_eq (res, basic_num_neg (basic_num_from_int (5))));
   printf ("basic_handle_fixed64_test OK\n");
   return 0;


### PR DESCRIPTION
## Summary
- avoid MIR_T_BLK return types by using BASIC_PROTO_NUM for MIR handle helpers
- provide fixed64 wrappers for MIR handle runtime functions
- adjust fixed64 handle test for pointer-based API

## Testing
- `make basic-test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbfaf4b083268a1fc30e2a501610