### PR TITLE
Add fixed-point BASIC tests to expose runtime crash

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -561,6 +561,7 @@ basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUI
 run-basic-tests:
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-ld$(EXE)
+	$(SRC_DIR)/basic/tests/run-tests.sh $(BUILD_DIR)/basic/basicc-fix$(EXE)
 	$(SRC_DIR)/basic/test/run-mbasic-tests.sh $(BUILD_DIR)/basic/basicc$(EXE)
 	$(BUILD_DIR)/basic/dfp_test$(EXE) > $(BUILD_DIR)/basic/dfp_test.out
 	diff $(SRC_DIR)/basic/test/dfp_test.out $(BUILD_DIR)/basic/dfp_test.out


### PR DESCRIPTION
## Summary
- run run-tests.sh for the fixed-point `basicc-fix` interpreter to surface current crash

## Testing
- `make basic-test` *(fails: param of call is of block type but arg is not of block type memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1054fb8488326aa6a8a94023e9de5