### PR TITLE
docs: clarify numeric constant emission

### DIFF
--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -11,6 +11,13 @@ MIR_item_t fixed64_add_proto, fixed64_add_import, fixed64_sub_proto, fixed64_sub
   fixed64_ge_import, fixed64_from_int_proto, fixed64_from_int_import, fixed64_to_int_proto,
   fixed64_to_int_import, fixed64_neg_proto, fixed64_neg_import;
 
+/*
+  Numeric constants must be emitted via the helpers `emit_num_const` or
+  `BASIC_MIR_new_num_op` so that values are materialized in memory and
+  referenced from MIR instructions.  Avoid creating constants with
+  `MIR_new_*_op` directly, which embeds immediates and breaks the fixed64
+  representation.
+*/
 static MIR_op_t fixed64_emit_num_const (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
   *p = v;


### PR DESCRIPTION
## Summary
- Document that numeric constants must use `emit_num_const`/`BASIC_MIR_new_num_op` so fixed64 values are emitted by reference

## Testing
- `make basic-test`

------
https://chatgpt.com/codex/tasks/task_e_68a11bc14f488326a557e5537d8f6aff