### PR TITLE
Ensure fixed64 runtime initialized for all MIR contexts

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -418,144 +418,153 @@ else
 endif
 
 $(BUILD_DIR)/basic/basicc$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
-        $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
-        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+	$(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
+	$(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 $(BUILD_DIR)/basic/basicc_ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
-        $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
-        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+	$(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
+	$(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 
 
 $(BUILD_DIR)/basic/basicc-ld$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
-        $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
-        $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/generic_128.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/ld2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basicc.c $(SRC_DIR)/basic/src/basic_runtime.c \
+	$(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c \
+	$(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/d2s.c $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/generic_128.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/ld2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/libdfp -DBASIC_USE_LONG_DOUBLE -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basicc-fix$(EXE): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUFF) \
-        $(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_fixed64_hooks.c $(SRC_DIR)/basic/src/basic_runtime.c \
-        $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
-        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basicc_fixed64.c $(SRC_DIR)/basic/src/basic_fixed64_hooks.c $(SRC_DIR)/basic/src/basic_runtime.c \
+	$(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_runtime_resolve.c $(SRC_DIR)/basic/src/basic_pool.c $(SRC_DIR)/basic/src/arena.c \
+	$(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/kitty_test$(EXE): \
-        $(SRC_DIR)/basic/test/kitty_test.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor/kitty $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/kitty_test.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor/kitty $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/hcolor_test$(EXE): \
-        $(SRC_DIR)/basic/test/hcolor_test.c \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/hcolor_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+	$(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basic_input_hash_test$(EXE): \
-        $(SRC_DIR)/basic/test/basic_input_hash_test.c \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/basic_input_hash_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+
+$(BUILD_DIR)/basic/basic_ctx_fixed64_mir_test$(EXE): \
+	$(SRC_DIR)/basic/test/basic_ctx_fixed64_mir_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basic_prng128_test$(EXE): \
-        $(SRC_DIR)/basic/test/basic_prng128_test.c \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/basic_prng128_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/basic_system_test$(EXE): \
-        $(SRC_DIR)/basic/test/basic_system_test.c \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/basic_system_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 $(BUILD_DIR)/basic/dfp_test$(EXE): \
-        $(SRC_DIR)/basic/test/dfp_test.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
-        $(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor/libdfp -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/dfp_test.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decContext.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decNumber.c \
+	$(SRC_DIR)/basic/src/vendor/libdfp/decQuad.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor/libdfp -DDECNUMDIGITS=34 $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/fixed64_test$(EXE): \
-        $(SRC_DIR)/basic/test/fixed64_test.c \
-        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/fixed64_test.c \
+	$(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/ld2s_test$(EXE): \
-        $(SRC_DIR)/basic/test/ld2s_test.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/generic_128.c \
-        $(SRC_DIR)/basic/src/vendor/ryu/ld2s.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/ld2s_test.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/generic_128.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/ld2s.c ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/src/vendor $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/parse_helpers_test$(EXE): \
-        $(SRC_DIR)/basic/test/parse_helpers_test.c \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(SRC_DIR)/basic/src/arena.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/test/parse_helpers_test.c \
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+	$(SRC_DIR)/basic/src/arena.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
 
 BASIC_NUM_SRCS = \
-        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c
+	$(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c
 
 $(BUILD_DIR)/basic/basic_num_scan_test$(EXE): \
-	$(SRC_DIR)/basic/test/basic_num_scan_test.c $(BASIC_NUM_SRCS) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 $^ -lm $(EXEO)$@
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
 	
 
 $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE): \
-        $(SRC_DIR)/basic/test/basic_num_fixed64_test.c $(BASIC_NUM_SRCS) ; mkdir -p $(BUILD_DIR)/basic; $(COMPILE_AND_LINK) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_USE_FIXED64 $^ -lm $(EXEO)$@
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB): \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD): \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_double.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_LONG_DOUBLE $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX): \
-        $(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_pool.c \
-        $(BASIC_NUM_SRCS) \
-        $(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
-        $(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
-        $(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
+	$(SRC_DIR)/basic/src/basic_runtime.c $(SRC_DIR)/basic/src/basic_runtime_fixed64.c $(SRC_DIR)/basic/src/basic_pool.c \
+        $(SRC_DIR)/basic/src/vendor/fixed64/fixed64.c \
+	$(SRC_DIR)/basic/src/vendor/ryu/f2s.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/kitty.c \
+	$(SRC_DIR)/basic/src/vendor/kitty/lodepng.c \
+	$(BUILD_DIR)/libmir.$(LIBSUFF) | $(BUILD_DIR)/basic ; $(CC) $(CPPFLAGS) -I$(SRC_DIR)/basic/include -I$(SRC_DIR)/basic/src -I$(SRC_DIR)/basic/src/vendor -I$(SRC_DIR)/basic/src/vendor/fixed64 -DBASIC_SRC_DIR=\"$(SRC_DIR)\" -DBASIC_USE_FIXED64 $(CFLAGS) $(LDFLAGS) $(BASIC_RUNTIME_FLAGS) $^ -lm $(EXEO)$@
 
 
-basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/basicc-fix$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/ld2s_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_prng128_test$(EXE) $(BUILD_DIR)/basic/basic_system_test$(EXE) $(BUILD_DIR)/basic/parse_helpers_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
+basic-test: $(BUILD_DIR)/libmir.$(LIBSUFF) $(BUILD_DIR)/basic/basicc$(EXE) $(BUILD_DIR)/basic/basicc-ld$(EXE) $(BUILD_DIR)/basic/basicc-fix$(EXE) $(BUILD_DIR)/basic/kitty_test$(EXE) $(BUILD_DIR)/basic/hcolor_test$(EXE) $(BUILD_DIR)/basic/dfp_test$(EXE) $(BUILD_DIR)/basic/fixed64_test$(EXE) $(BUILD_DIR)/basic/ld2s_test$(EXE) $(BUILD_DIR)/basic/basic_num_scan_test$(EXE) $(BUILD_DIR)/basic/basic_input_hash_test$(EXE) $(BUILD_DIR)/basic/basic_ctx_fixed64_mir_test$(EXE) $(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE) $(BUILD_DIR)/basic/basic_prng128_test$(EXE) $(BUILD_DIR)/basic/basic_system_test$(EXE) $(BUILD_DIR)/basic/parse_helpers_test$(EXE) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_LD) $(BUILD_DIR)/basic/$(BASIC_RUNTIME_LIB_FIX) $(BUILD_DIR)/mir-bin-run$(EXE) run-basic-tests
 
 
 run-basic-tests:
@@ -571,6 +580,7 @@ run-basic-tests:
 	$(BUILD_DIR)/basic/basic_input_hash_test$(EXE)
 	$(BUILD_DIR)/basic/basic_num_fixed64_test$(EXE)
 	$(BUILD_DIR)/basic/basic_prng128_test$(EXE)
+	$(BUILD_DIR)/basic/basic_ctx_fixed64_mir_test$(EXE)
 	$(BUILD_DIR)/basic/basic_system_test$(EXE) > $(BUILD_DIR)/basic/basic_system_test.out
 	diff $(SRC_DIR)/basic/test/basic_system_test.out $(BUILD_DIR)/basic/basic_system_test.out
 	$(BUILD_DIR)/basic/basicc $(BUILD_DIR)/basic/samples/unicode_pattern_random4.bas

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -100,6 +100,27 @@ if(BUILD_TESTING)
   endif()
   add_test(NAME basic_num_fixed64_test COMMAND basic_num_fixed64_test)
 
+  add_executable(basic_ctx_fixed64_mir_test
+    test/basic_ctx_fixed64_mir_test.c
+    src/basic_runtime.c
+    src/basic_runtime_fixed64.c
+    src/basic_pool.c
+    src/vendor/fixed64/fixed64.c
+    src/vendor/ryu/f2s.c
+    src/vendor/kitty/kitty.c
+    src/vendor/kitty/lodepng.c)
+  target_compile_definitions(basic_ctx_fixed64_mir_test PRIVATE BASIC_USE_FIXED64 BASIC_SRC_DIR=\"${CMAKE_SOURCE_DIR}\")
+  target_include_directories(basic_ctx_fixed64_mir_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/fixed64)
+  target_link_libraries(basic_ctx_fixed64_mir_test mir)
+  if(UNIX)
+    target_link_libraries(basic_ctx_fixed64_mir_test m)
+  endif()
+  add_test(NAME basic_ctx_fixed64_mir_test COMMAND basic_ctx_fixed64_mir_test)
+
   add_executable(ld2s_test
     test/ld2s_test.c
     src/vendor/ryu/generic_128.c

--- a/basic/src/basic_runtime.c
+++ b/basic/src/basic_runtime.c
@@ -1158,6 +1158,7 @@ static basic_num_t basic_mir_ctx_impl (void) {
   static basic_num_t ctx_handle = BASIC_ZERO;
   if (basic_num_ne (ctx_handle, BASIC_ZERO)) return ctx_handle;
   MIR_context_t ctx = MIR_init ();
+  basic_runtime_fixed64_init (ctx);
   ctx_handle = new_handle (H_CTX, ctx, ctx);
   return ctx_handle;
 }

--- a/basic/src/basicc_core.c
+++ b/basic/src/basicc_core.c
@@ -1,6 +1,10 @@
 #include "basic_common.h"
 #include "basic_num_hooks.h"
 
+#ifdef BASIC_USE_FIXED64
+#include "basic_runtime_fixed64.h"
+#endif
+
 #if defined(BASIC_USE_LONG_DOUBLE)
 #define MIR_DMOV MIR_LDMOV
 #define MIR_DNEG MIR_LDNEG
@@ -5994,6 +5998,9 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   MIR_context_t ctx = MIR_init ();
   MIR_module_t module = MIR_new_module (ctx, "BASIC");
   basic_num_init (ctx);
+#ifdef BASIC_USE_FIXED64
+  basic_runtime_fixed64_init (ctx);
+#endif
   print_proto = MIR_new_proto (ctx, "basic_print_p", 0, NULL, 1, BASIC_MIR_NUM_T, "x");
   print_import = MIR_new_import (ctx, "basic_print");
   prints_proto = MIR_new_proto (ctx, "basic_print_str_p", 0, NULL, 1, MIR_T_P, "s");

--- a/basic/test/basic_ctx_fixed64_mir_test.c
+++ b/basic/test/basic_ctx_fixed64_mir_test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+#include "basic_runtime.h"
+#include "basic_num.h"
+
+int main (void) {
+  basic_num_t ctx, mod, func, r1, r2, tmp;
+
+  basic_mir_ctx (&ctx);
+  basic_mir_mod (&mod, ctx, "test");
+  basic_mir_func (&func, mod, "add", basic_num_from_int (0));
+  basic_mir_reg (&r1, func);
+  basic_mir_reg (&r2, func);
+
+  basic_mir_emit (&tmp, func, "MOV", r1, basic_num_from_int (5), BASIC_ZERO);
+  basic_mir_emit (&tmp, func, "MOV", r2, basic_num_from_int (3), BASIC_ZERO);
+  basic_mir_emit (&tmp, func, "DADD", r1, r1, r2);
+  basic_mir_ret (&tmp, func, r1);
+  basic_mir_finish (&tmp, mod);
+  basic_mir_run (&tmp, func, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO, BASIC_ZERO);
+
+  assert (basic_num_to_int (tmp) == 8);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- initialize fixed64 runtime whenever a MIR context is created
- hook fixed64 runtime into BASIC compiler module creation
- add test ensuring runtime init for MIR contexts and wire into build

## Testing
- `make basic-test` *(fails: import of undefined item basic_time_str)*

------
https://chatgpt.com/codex/tasks/task_e_68a11baf91f883269c8da028f4ceb6bb