### PR TITLE
Avoid duplicate fixed64 runtime init

### DIFF
--- a/basic/src/basicc_core.c
+++ b/basic/src/basicc_core.c
@@ -6000,7 +6000,7 @@ static void gen_program (LineVec *prog, int jit, int asm_p, int obj_p, int bin_p
   MIR_module_t module = MIR_new_module (ctx, "BASIC");
   basic_num_init (ctx);
 #ifdef BASIC_USE_FIXED64
-  basic_runtime_fixed64_init (ctx);
+  /* numeric hooks already initialize fixed64 runtime */
 #endif
   print_proto = MIR_new_proto (ctx, "basic_print_p", 0, NULL, 1, BASIC_MIR_NUM_T, "x");
   print_import = MIR_new_import (ctx, "basic_print");


### PR DESCRIPTION
## Summary
- avoid redundant `basic_runtime_fixed64_init` call because numeric hooks already initialize it

## Testing
- `make basic-test` *(failed: param of call is of block type but arg is not of block type memory)*


------
https://chatgpt.com/codex/tasks/task_e_68a1202100388326b7d0fdac5cfca954