### PR TITLE
Add interpreter run for mir_runtime_fix

### DIFF
--- a/basic/tests/run-tests.sh
+++ b/basic/tests/run-tests.sh
@@ -243,6 +243,12 @@ PY
                diff "$ROOT/basic/test/basic_system_fix_test.out" "$ROOT/basic/basic_system_fix_test.out"
                echo "basic_system_fix_test OK"
 
+               echo "Running mir_runtime_fix (interp)"
+               "$BASICC" "$ROOT/basic/test/mir_runtime_fix.bas" > "$ROOT/basic/mir_runtime_fix.out"
+               diff "$ROOT/basic/test/mir_runtime_fix.out" "$ROOT/basic/mir_runtime_fix.out"
+               rm -f "$ROOT/basic/mir_runtime_fix.out"
+               echo "mir_runtime_fix (interp) OK"
+
                echo "Running mir_runtime_fix (JIT)"
                "$BASICC" -j "$ROOT/basic/test/mir_runtime_fix.bas" > "$ROOT/basic/mir_runtime_fix.out"
                diff "$ROOT/basic/test/mir_runtime_fix.out" "$ROOT/basic/mir_runtime_fix.out"


### PR DESCRIPTION
## Summary
- ensure test suite runs mir_runtime_fix program via interpreter and JIT

## Testing
- `./basic/fixed64_test > /tmp/fixed64_test.out && tail -n 20 /tmp/fixed64_test.out`
- `make basic-test` *(failed: make: *** [GNUmakefile:472: basic/basic_input_hash_test] Interrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68a1c529122c8326b5b0a5c8e3d629ac