### PR TITLE
Add mir_pass_arg hook for BASIC numeric arguments

### DIFF
--- a/basic/src/basic_num_hooks.h
+++ b/basic/src/basic_num_hooks.h
@@ -12,6 +12,7 @@ typedef struct {
                     MIR_op_t src1, MIR_op_t src2);
   void (*mir_i2n) (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src);
   void (*mir_n2i) (MIR_context_t ctx, MIR_item_t func, MIR_op_t dst, MIR_op_t src);
+  void (*mir_pass_arg) (MIR_context_t ctx, MIR_item_t func, MIR_op_t *op);
 } basic_num_hooks_t;
 
 extern basic_num_hooks_t basic_num_hooks;

--- a/basic/src/basicc.c
+++ b/basic/src/basicc.c
@@ -32,12 +32,20 @@ static void basic_mir_n2i_default (MIR_context_t ctx, MIR_item_t func, MIR_op_t 
 #endif
 }
 
+static void basic_mir_pass_arg_default (MIR_context_t ctx, MIR_item_t func, MIR_op_t *op) {
+  /* For standard float/double, the register op is already correct. */
+  (void) ctx;
+  (void) func;
+  (void) op;
+}
+
 basic_num_hooks_t basic_num_hooks = {
   .mir_binop = basic_mir_binop_default,
   .mir_unop = basic_mir_unop_default,
   .mir_bcmp = basic_mir_bcmp_default,
   .mir_i2n = basic_mir_i2n_default,
   .mir_n2i = basic_mir_n2i_default,
+  .mir_pass_arg = basic_mir_pass_arg_default,
 };
 
 void basic_num_init (MIR_context_t ctx) { (void) ctx; }

--- a/basic/src/basicc_core.c
+++ b/basic/src/basicc_core.c
@@ -4291,8 +4291,11 @@ static void print_item (Node *e, Node *next) {
     return;
   }
   MIR_reg_t r = gen_expr (g_ctx, g_func, &g_vars, e);
-  call1 (e->is_str ? prints_proto : print_proto, e->is_str ? prints_import : print_import,
-         MIR_new_reg_op (g_ctx, r));
+  MIR_op_t op = MIR_new_reg_op (g_ctx, r);
+  if (!e->is_str) {
+    basic_num_hooks.mir_pass_arg (g_ctx, g_func, &op);
+  }
+  call1 (e->is_str ? prints_proto : print_proto, e->is_str ? prints_import : print_import, op);
   if (!e->is_str && next != NULL && !next->is_str) print_str ((MIR_str_t) {2, " "});
 }
 
@@ -4302,8 +4305,12 @@ static void print_hash_str (MIR_reg_t fn, MIR_str_t str) {
 
 static void print_hash_item (MIR_reg_t fn, Node *e, Node *next) {
   MIR_reg_t r = gen_expr (g_ctx, g_func, &g_vars, e);
+  MIR_op_t op = MIR_new_reg_op (g_ctx, r);
+  if (!e->is_str) {
+    basic_num_hooks.mir_pass_arg (g_ctx, g_func, &op);
+  }
   call2 (e->is_str ? prinths_proto : printh_proto, e->is_str ? prinths_import : printh_import,
-         MIR_new_reg_op (g_ctx, fn), MIR_new_reg_op (g_ctx, r));
+         MIR_new_reg_op (g_ctx, fn), op);
   if (!e->is_str && next != NULL && !next->is_str) print_hash_str (fn, (MIR_str_t) {2, " "});
 }
 

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -79,12 +79,17 @@ static void basic_fixed64_init (MIR_context_t ctx) {
   fixed64_to_int_import = MIR_new_import (ctx, "fixed64_to_int");
 }
 
+static void basic_mir_pass_arg_fixed64 (MIR_context_t ctx, MIR_item_t func, MIR_op_t *op) {
+  *op = basic_mem (ctx, func, *op, BASIC_MIR_NUM_T);
+}
+
 basic_num_hooks_t basic_num_hooks = {
   .mir_binop = basic_mir_binop,
   .mir_unop = basic_mir_unop,
   .mir_bcmp = basic_mir_bcmp,
   .mir_i2n = basic_mir_i2n,
   .mir_n2i = basic_mir_n2i,
+  .mir_pass_arg = basic_mir_pass_arg_fixed64,
 };
 
 void basic_num_init (MIR_context_t ctx) { basic_fixed64_init (ctx); }


### PR DESCRIPTION
## Summary
- add `mir_pass_arg` to numeric hook table
- implement argument hook for fixed64 and default builds
- use argument hook when printing values

## Testing
- `make basic-test` (fails: param of call is of block type but arg is not of block type memory)


------
https://chatgpt.com/codex/tasks/task_e_68a1e0f7dc008326bb8a4457008b3704