### PR TITLE
Use distinct block type for fixed64 numbers

### DIFF
--- a/basic/src/basic_runtime_fixed64.h
+++ b/basic/src/basic_runtime_fixed64.h
@@ -8,7 +8,7 @@
 
 #ifdef BASIC_USE_FIXED64
 
-#define BASIC_MIR_NUM_T MIR_T_BLK
+#define BASIC_MIR_NUM_T (MIR_T_BLK + 1)
 static inline MIR_op_t BASIC_MIR_new_num_op (MIR_context_t ctx, basic_num_t v) {
   basic_num_t *p = basic_pool_alloc (sizeof (basic_num_t));
   *p = v;

--- a/basic/src/basicc_fixed64.c
+++ b/basic/src/basicc_fixed64.c
@@ -105,7 +105,7 @@ static inline MIR_item_t basic_proto_num (MIR_context_t ctx, const char *name, s
   for (size_t i = 0; i < nargs; ++i) {
     all_vars[i + 1] = vars[i];
     if (all_vars[i + 1].type == BASIC_MIR_NUM_T) {
-      all_vars[i + 1].type = MIR_T_BLK;
+      all_vars[i + 1].type = MIR_T_BLK + 1;
       all_vars[i + 1].size = sizeof (basic_num_t);
     }
   }


### PR DESCRIPTION
## Summary
- define fixed64 numeric type macro as `(MIR_T_BLK + 1)`
- ensure prototype helper emits block type for fixed64 parameters

## Testing
- `make basic-test` *(fails: param of call is of block type but arg is not of block type memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ab42f8483268722b5acb1aa5b10